### PR TITLE
feat: TeamsAPI guard + bump to 1.0.3

### DIFF
--- a/.github/workflows/release-modrinth.yml
+++ b/.github/workflows/release-modrinth.yml
@@ -145,7 +145,9 @@ jobs:
               'name':          f'PvPIndex Battles {v} (Paper)',
               'version_number': f'{v}-paper',
               'changelog':     c,
-              'dependencies':  [],
+              'dependencies':  [
+                  {'project_id': '2NJKwgXC', 'version_id': None, 'dependency_type': 'optional'}
+              ],
               'game_versions': [
                   '1.21','1.21.1','1.21.2','1.21.3','1.21.4','1.21.5',
                   '1.21.6','1.21.7','1.21.8','1.21.9','1.21.10','1.21.11',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
+## [1.0.3] - 2026-05-17
+
+### Added
+- **TeamsAPI guard**: optional integration with [TeamsAPI](https://modrinth.com/plugin/teams-api) that prevents players on the same team from challenging each other. Disabled by default (`teams_guard.block_same_team: false`). Requires TeamsAPI + a compatible team plugin on the server; if either is absent, the feature is silently skipped (fail-open).
+- New `TeamsGuardService` class in `platform-paper` — encapsulates the same-team lookup with graceful `NoClassDefFoundError` handling so the plugin loads cleanly whether or not TeamsAPI is on the classpath.
+- `TeamsAPI` added to `softdepend` in `plugin.yml` so Paper loads it before PvPIndex Battles when both plugins are present.
+- New config section `teams_guard` in `config.yml`.
+- New lang keys `challenge.same_team` and `challenge.same_team_target` in all bundled language files (en, de, nl, es, pl, zh).
+- JitPack repository added to parent `pom.xml`; `teams-api:1.5.0` added as a `provided` dependency in `pvpindex-platform-paper`.
+
+---
+
 ## [1.0.2] - 2026-05-05
 
 ### Added
@@ -124,7 +136,8 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
-[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/PVP-Index/pvpindex-battles/releases/tag/v1.0.0

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/pom.xml
+++ b/bootstrap-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/src/main/resources/bungee.yml
+++ b/bootstrap-bungeecord/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: PvPIndex-Proxy
 main: com.pvpindex.bungeecord.PvPIndexBungeePlugin
-version: "1.0.2"
+version: "1.0.3"
 author: PvPIndex Team
 description: Cross-server battle tracking and coordination for PvPIndex (BungeeCord)

--- a/bootstrap-paper/pom.xml
+++ b/bootstrap-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -57,6 +57,7 @@ import com.pvpindex.battles.world.SchematicLoader;
 import com.pvpindex.battles.world.SchematicStrategy;
 import com.pvpindex.battles.world.WorldCopyStrategy;
 import com.pvpindex.battles.world.WorldGeneratorService;
+import com.pvpindex.battles.teams.TeamsGuardService;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -342,6 +343,14 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		if (lobbyNetworkService != null && lobbyNetworkService.isActive()) {
 			challengeManager.setLobbyServices(lobbyNetworkService.challengeSync(), networkPlayerCache,
 					lobbyNetworkService.transfers(), configManager.lobbySettings().velocityServerName());
+		}
+
+		// TeamsAPI guard — optional, disabled by default
+		TeamsGuardService teamsGuard = new TeamsGuardService(
+				configManager.settings().teamsGuardEnabled(), getLogger());
+		challengeManager.setTeamsGuard(teamsGuard);
+		if (teamsGuard.isEnabled()) {
+			getLogger().info("TeamsAPI guard enabled: same-team challenges will be blocked.");
 		}
 		battleGuiCommand.setChallengeManager(challengeManager);
 		battleGuiListener.setChallengeManager(challengeManager);

--- a/bootstrap-paper/src/main/resources/config.yml
+++ b/bootstrap-paper/src/main/resources/config.yml
@@ -206,3 +206,11 @@ proxy:
   secret: ""
   # How often (in ticks) to send a heartbeat to the proxy (0 to disable).
   heartbeat_interval_ticks: 200
+
+# ─── TeamsAPI guard ───────────────────────────────────────────────────────────
+# Optional integration with TeamsAPI (https://modrinth.com/plugin/teams-api).
+# When enabled, players on the same team cannot challenge each other.
+# Requires the TeamsAPI plugin and a compatible team plugin on the server.
+# If TeamsAPI is absent or no provider is registered, this setting has no effect.
+teams_guard:
+  block_same_team: false

--- a/bootstrap-paper/src/main/resources/lang/de.yml
+++ b/bootstrap-paper/src/main/resources/lang/de.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&cUngueltige Herausforderungs-ID."
   smp_warning: "&c&lWARNUNG: &eDies ist ein SMP-Kampf! Wenn du verlierst, &c&ldropst du alle deine Items &eund der Gewinner kann sie aufsammeln. Moechtest du fortfahren?"
   gui_hint: "&7Verwende /battle challenge <Spieler> um eine Herausforderung zu starten."
+  same_team: "&cDu kannst kein Teammitglied herausfordern."
+  same_team_target: "&c%player% hat versucht, dich herauszufordern, aber ihr seid im selben Team."
 
 replay:
   exported: "&aReplay exportiert: %file%"

--- a/bootstrap-paper/src/main/resources/lang/en.yml
+++ b/bootstrap-paper/src/main/resources/lang/en.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&cInvalid challenge ID."
   smp_warning: "&c&lWARNING: &eThis is an SMP battle! If you lose, &c&lyou will drop all your items &eand the winner can take them. Do you wish to proceed?"
   gui_hint: "&7Use /battle challenge <player> to start a challenge."
+  same_team: "&cYou cannot challenge a teammate."
+  same_team_target: "&c%player% tried to challenge you, but you are on the same team."
 
 replay:
   exported: "&aReplay exported: %file%"

--- a/bootstrap-paper/src/main/resources/lang/es.yml
+++ b/bootstrap-paper/src/main/resources/lang/es.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&cID de desafio no valido."
   smp_warning: "&c&lADVERTENCIA: &eEsta es una batalla SMP! Si pierdes, &c&lsoltaras todos tus objetos &ey el ganador podra tomarlos. Deseas continuar?"
   gui_hint: "&7Usa /battle challenge <jugador> para iniciar un desafio."
+  same_team: "&cNo puedes desafiar a un companero de equipo."
+  same_team_target: "&c%player% intento desafiarte, pero estais en el mismo equipo."
 
 replay:
   exported: "&aReplay exportado: %file%"

--- a/bootstrap-paper/src/main/resources/lang/nl.yml
+++ b/bootstrap-paper/src/main/resources/lang/nl.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&cOngeldig uitdaging-ID."
   smp_warning: "&c&lWAARSCHUWING: &eDit is een SMP-gevecht! Als je verliest, &c&ldrop je al je items &een de winnaar kan ze pakken. Wil je doorgaan?"
   gui_hint: "&7Gebruik /battle challenge <speler> om een uitdaging te starten."
+  same_team: "&cJe kunt geen teamgenoot uitdagen."
+  same_team_target: "&c%player% probeerde je uit te dagen, maar jullie zitten in hetzelfde team."
 
 replay:
   exported: "&aReplay geexporteerd: %file%"

--- a/bootstrap-paper/src/main/resources/lang/pl.yml
+++ b/bootstrap-paper/src/main/resources/lang/pl.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&cNieprawidlowe ID wyzwania."
   smp_warning: "&c&lUWAGA: &eTo walka SMP! Jesli przegrasz, &c&lupuscisz wszystkie swoje przedmioty &ea zwyciezca moze je zabrac. Czy chcesz kontynuowac?"
   gui_hint: "&7Uzyj /battle challenge <gracz> aby rozpoczac wyzwanie."
+  same_team: "&cNie mozesz wyzwac czlonka swojej druzyny."
+  same_team_target: "&c%player% probował Cie wyzwac, ale jestescie w tym samym zespole."
 
 replay:
   exported: "&aReplay wyeksportowany: %file%"

--- a/bootstrap-paper/src/main/resources/lang/zh.yml
+++ b/bootstrap-paper/src/main/resources/lang/zh.yml
@@ -60,6 +60,8 @@ challenge:
   invalid_id: "&c无效的挑战ID。"
   smp_warning: "&c&l警告: &e这是一场SMP战斗！如果你输了，&c&l你会掉落所有物品&e，胜者可以拾取。你确定要继续吗？"
   gui_hint: "&7使用 /battle challenge <玩家> 发起挑战。"
+  same_team: "&c你不能向队友发起挑战。"
+  same_team_target: "&c%player% 试图向你发起挑战，但你们在同一队伍中。"
 
 replay:
   exported: "&a回放已导出: %file%"

--- a/bootstrap-paper/src/main/resources/plugin.yml
+++ b/bootstrap-paper/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: PvPIndexBattles
-version: 1.0.2
+version: 1.0.3
 main: com.pvpindex.battles.PvPIndexBattlesPlugin
 api-version: '1.21'
 authors: [PvPIndex]
-softdepend: [PlaceholderAPI]
+softdepend: [PlaceholderAPI, TeamsAPI]
 commands:
   pvpindex:
     description: PvPIndex battle command root

--- a/bootstrap-velocity/pom.xml
+++ b/bootstrap-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-velocity/src/main/resources/velocity-plugin.json
+++ b/bootstrap-velocity/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
 	"id": "pvpindex-proxy",
 	"name": "PvPIndex Proxy",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Cross-server battle tracking and coordination for PvPIndex",
 	"authors": ["PvPIndex Team"],
 	"main": "com.pvpindex.velocity.PvPIndexVelocityPlugin",

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/com/pvpindex/battles/config/PluginSettings.java
+++ b/common/src/main/java/com/pvpindex/battles/config/PluginSettings.java
@@ -38,5 +38,7 @@ public record PluginSettings(
         // Velocity proxy integration
         boolean proxyEnabled,
         String proxySecret,
-        int proxyHeartbeatIntervalTicks
+        int proxyHeartbeatIntervalTicks,
+        // TeamsAPI guard
+        boolean teamsGuardEnabled
 ) {}

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.1.21.x/pom.xml
+++ b/paper-versions/paper.1.21.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.26.1.x/pom.xml
+++ b/paper-versions/paper.26.1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform-bungeecord/pom.xml
+++ b/platform-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/pom.xml
+++ b/platform-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -39,6 +39,10 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ez-plugins</groupId>
+            <artifactId>teams-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/platform-paper/src/main/java/com/pvpindex/battles/challenge/ChallengeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/challenge/ChallengeManager.java
@@ -7,6 +7,7 @@ import com.pvpindex.battles.messaging.NetworkPlayerCache;
 import com.pvpindex.battles.messaging.PaperMessenger;
 import com.pvpindex.battles.network.ChallengeSyncService;
 import com.pvpindex.battles.queue.BattleQueueService;
+import com.pvpindex.battles.teams.TeamsGuardService;
 import com.pvpindex.battles.util.DebugLogger;
 import com.pvpindex.battles.util.MessageService;
 import java.time.Instant;
@@ -53,6 +54,7 @@ public final class ChallengeManager {
 	private NetworkPlayerCache lobbyPlayerCache;
 	private com.pvpindex.battles.network.TransferRequester transferRequester;
 	private String velocityServerName;
+	private TeamsGuardService teamsGuard;
 
 	public ChallengeManager(JavaPlugin plugin, PaperMessenger paperMessenger,
 			BattleQueueService queueService, GameModeRegistry gameModeRegistry,
@@ -72,6 +74,10 @@ public final class ChallengeManager {
 
 	public void setArrivalListener(ChallengeArrivalListener arrivalListener) {
 		this.arrivalListener = arrivalListener;
+	}
+
+	public void setTeamsGuard(TeamsGuardService teamsGuard) {
+		this.teamsGuard = teamsGuard;
 	}
 
 	/**
@@ -107,6 +113,18 @@ public final class ChallengeManager {
 		if (hasOutgoing(challenger.getUniqueId(), targetName)) {
 			messageService.send(challenger, "challenge.already_pending");
 			return;
+		}
+
+		// TeamsAPI guard — block same-team challenges when enabled (standalone only;
+		// cross-server challenges are re-checked in startBattle when both UUIDs are known).
+		if (teamsGuard != null && teamsGuard.isEnabled()) {
+			Player localTarget = Bukkit.getPlayerExact(targetName);
+			if (localTarget != null && localTarget.isOnline()) {
+				if (teamsGuard.isSameTeam(challenger.getUniqueId(), localTarget.getUniqueId())) {
+					messageService.send(challenger, "challenge.same_team");
+					return;
+				}
+			}
 		}
 
 		UUID challengeId = UUID.randomUUID();
@@ -332,6 +350,15 @@ public final class ChallengeManager {
 		if (modeOpt.isEmpty()) {
 			messageService.send(challenger, "challenge.unknown_mode", "%mode%", modeId);
 			messageService.send(target, "challenge.unknown_mode", "%mode%", modeId);
+			return;
+		}
+
+		// TeamsAPI guard — final check with both UUIDs known (covers all modes).
+		if (teamsGuard != null && teamsGuard.isSameTeam(challengerUuid, targetUuid)) {
+			messageService.send(challenger, "challenge.same_team");
+			messageService.send(target, "challenge.same_team_target", "%player%", challenger.getName());
+			debug.logChallenge("SAME_TEAM_BLOCKED", null,
+					challenger.getName() + " vs " + target.getName());
 			return;
 		}
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/config/ConfigManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/config/ConfigManager.java
@@ -71,7 +71,9 @@ public class ConfigManager {
 				// Velocity proxy integration
 				cfg.getBoolean("proxy.enabled", false),
 				cfg.getString("proxy.secret", ""),
-				Math.max(1, cfg.getInt("proxy.heartbeat_interval_ticks", 200))
+				Math.max(1, cfg.getInt("proxy.heartbeat_interval_ticks", 200)),
+				// TeamsAPI guard
+				cfg.getBoolean("teams_guard.block_same_team", false)
 		);
 
         replaySettings = new ReplaySettings(

--- a/platform-paper/src/main/java/com/pvpindex/battles/teams/TeamsGuardService.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/teams/TeamsGuardService.java
@@ -1,0 +1,63 @@
+package com.pvpindex.battles.teams;
+
+import com.skyblockexp.teamsapi.api.TeamsAPI;
+import com.skyblockexp.teamsapi.api.TeamsService;
+import com.skyblockexp.teamsapi.model.Team;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Optional guard that prevents players on the same team from battling each
+ * other.
+ *
+ * <p>Requires <a href="https://modrinth.com/plugin/teams-api">TeamsAPI</a>
+ * to be installed on the server. If the plugin is absent or no team provider
+ * is registered, the guard is transparently skipped so that challenges work
+ * exactly as before.
+ *
+ * <p>Enabled by setting {@code teams_guard.block_same_team: true} in
+ * {@code config.yml} (disabled by default).
+ */
+public final class TeamsGuardService {
+
+    private final boolean enabled;
+    private final Logger logger;
+
+    public TeamsGuardService(boolean enabled, Logger logger) {
+        this.enabled = enabled;
+        this.logger = logger;
+    }
+
+    /**
+     * Returns {@code true} when the two players share the same team AND
+     * the guard is enabled AND a TeamsAPI provider is available.
+     *
+     * <p>Any unexpected error (missing class, provider exception, …) is caught
+     * and the method returns {@code false} (fail-open) so that a misconfigured
+     * or absent TeamsAPI never blocks legitimate challenges.
+     *
+     * @param playerA UUID of the first player
+     * @param playerB UUID of the second player
+     * @return {@code true} if the challenge should be blocked
+     */
+    public boolean isSameTeam(UUID playerA, UUID playerB) {
+        if (!enabled) return false;
+        try {
+            if (!TeamsAPI.isAvailable()) return false;
+            TeamsService service = TeamsAPI.getService();
+            Optional<Team> teamA = service.getPlayerTeam(playerA);
+            if (teamA.isEmpty()) return false;
+            Optional<Team> teamB = service.getPlayerTeam(playerB);
+            if (teamB.isEmpty()) return false;
+            return teamA.get().getId().equals(teamB.get().getId());
+        } catch (NoClassDefFoundError | Exception e) {
+            logger.fine("[TeamsGuard] Could not query TeamsAPI: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/platform-paper/src/test/java/com/pvpindex/battles/BattleBatchSchedulerTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/BattleBatchSchedulerTest.java
@@ -161,7 +161,8 @@ class BattleBatchSchedulerTest {
                 false, 0.1, 2,
                 false, 40, 20,
                 100,
-                false, "", 0
+                false, "", 0,
+                false
         );
     }
 

--- a/platform-paper/src/test/java/com/pvpindex/battles/BattleServiceTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/BattleServiceTest.java
@@ -78,7 +78,9 @@ class BattleServiceTest {
                 // cleanup
                 100,
                 // proxy
-                false, "", 0
+                false, "", 0,
+                // teams guard
+                false
         );
         BattleReplayRecorder recorder = new BattleReplayRecorder(plugin, new ObjectMapper(), ReplayDetailLevel.HIGH);
         PvPIndexApiClient apiClient = new PvPIndexApiClient(settings, new ObjectMapper()) {

--- a/platform-paper/src/test/java/com/pvpindex/battles/PacketCaptureWiringTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/PacketCaptureWiringTest.java
@@ -175,7 +175,8 @@ class PacketCaptureWiringTest {
                 false, 0.1, 2,
                 false, 40, 20,
                 100,
-                false, "", 0
+                false, "", 0,
+                false
         );
     }
 }

--- a/platform-velocity/pom.xml
+++ b/platform-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.pvpindex</groupId>
     <artifactId>pvpindex-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <name>PvPIndex Parent</name>
@@ -46,6 +46,10 @@
         <repository>
             <id>extendedclip-repo</id>
             <url>https://repo.extendedclip.com/releases/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -142,6 +146,14 @@
                 <groupId>net.md-5</groupId>
                 <artifactId>bungeecord-api</artifactId>
                 <version>1.21-R0.4</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- TeamsAPI (optional soft-dependency) -->
+            <dependency>
+                <groupId>com.github.ez-plugins</groupId>
+                <artifactId>teams-api</artifactId>
+                <version>1.5.0</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
- Add optional TeamsAPI integration (modrinth.com/plugin/teams-api) to prevent players on the same team from challenging each other. Disabled by default (teams_guard.block_same_team: false).
- New TeamsGuardService in platform-paper; fail-open on missing plugin.
- TeamsAPI added to softdepend in plugin.yml.
- New config section teams_guard in config.yml.
- New lang keys challenge.same_team / challenge.same_team_target in all six bundled language files (en, de, nl, es, pl, zh).
- teams-api:1.5.0 (provided) added via JitPack in pom.xml.
- Update PluginSettings test constructors for new teamsGuardEnabled field.
- Bump all module versions 1.0.2 -> 1.0.3.
- Update CHANGELOG with 1.0.3 entry and comparison links.