### PR TITLE
feat: optionally block commands while in battle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,22 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
+## [1.0.4] - 2026-05-22
+
+### Added
+- **Command blocking during battles**: commands are now blocked by default while a player is in an active battle. Configurable via `battle_commands` in config.yml with a whitelist of allowed commands (`/battle`, `/msg`, `/r`, `/reply`, `/tell` by default). Players with `pvpindex.battle.commands.bypass` permission can still use all commands. Closes [#19](https://github.com/PVP-Index/pvpindex-battles/issues/19).
+- New `BattleCommandBlockListener` in `platform-paper` that intercepts `PlayerCommandPreprocessEvent` at `LOWEST` priority.
+- New config section `battle_commands` in `config.yml` with `block_commands` toggle and `allowed_commands` whitelist.
+- New permission `pvpindex.battle.commands.bypass` (default: op) to bypass command blocking.
+- New lang key `battle.command_blocked` in all bundled language files (en, de, nl, es, pl, zh).
+
+---
+
 ## [1.0.3] - 2026-05-17
 
 ### Added
 - **TeamsAPI guard**: optional integration with [TeamsAPI](https://modrinth.com/plugin/teams-api) that prevents players on the same team from challenging each other. Disabled by default (`teams_guard.block_same_team: false`). Requires TeamsAPI + a compatible team plugin on the server; if either is absent, the feature is silently skipped (fail-open).
-- New `TeamsGuardService` class in `platform-paper` — encapsulates the same-team lookup with graceful `NoClassDefFoundError` handling so the plugin loads cleanly whether or not TeamsAPI is on the classpath.
+- New `TeamsGuardService` class in `platform-paper` that encapsulates the same-team lookup with graceful `NoClassDefFoundError` handling so the plugin loads cleanly whether or not TeamsAPI is on the classpath.
 - `TeamsAPI` added to `softdepend` in `plugin.yml` so Paper loads it before PvPIndex Battles when both plugins are present.
 - New config section `teams_guard` in `config.yml`.
 - New lang keys `challenge.same_team` and `challenge.same_team_target` in all bundled language files (en, de, nl, es, pl, zh).
@@ -148,7 +159,8 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
-[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ mvn clean package
 
 Output:
 
-- `bootstrap-paper/target/PvPIndexBattles-1.0.2.jar` - drop into Paper `plugins/`
-- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.0.2.jar` - drop into Velocity `plugins/`
-- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.0.2.jar` - drop into BungeeCord `plugins/`
+- `bootstrap-paper/target/PvPIndexBattles-1.0.4.jar` - drop into Paper `plugins/`
+- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.0.4.jar` - drop into Velocity `plugins/`
+- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.0.4.jar` - drop into BungeeCord `plugins/`
 
 The Paper JAR auto-detects your server version (1.21.x or 26.1.x) at startup. No manual configuration needed for version selection.
 
@@ -42,7 +42,7 @@ The Paper JAR auto-detects your server version (1.21.x or 26.1.x) at startup. No
 | [Multi-Proxy Setup](docs/SETUP-MULTI-PROXY.md) | Running multiple proxies with Redis |
 | [Architecture](docs/ARCHITECTURE.md) | Module map, dependency flow, version detection |
 | [Configuration](docs/CONFIGURATION.md) | Full config.yml and config.properties reference |
-| [Commands](docs/COMMANDS.md) | All commands and permissions for Paper and Velocity |
+| [Commands](docs/COMMANDS.md) | All commands and permissions for Paper, Velocity, and BungeeCord |
 | [Version Support](docs/VERSIONING.md) | Supported Paper versions, what changed, adding new versions |
 | [Development](docs/DEVELOPMENT.md) | Building, testing, code style, contributing |
 
@@ -88,6 +88,7 @@ pvpindex-parent
 - **Configurable GUI** via `gui.yml` for full customisation of materials, slots, titles, and colours
 - **WorldNormalizer** display layer mapping raw mode IDs to friendly names
 - **Multi-language support** (English, Dutch, German, Polish, Chinese, Spanish) with custom language file support
+- **Command blocking** during battles with configurable whitelist and bypass permission
 - **Debug logging** system gated behind config flag
 - **Player state snapshots** with crash recovery and cross-server transfer stabilisation
 - **Custom Bukkit events** for developer integration

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/pom.xml
+++ b/bootstrap-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/src/main/resources/bungee.yml
+++ b/bootstrap-bungeecord/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: PvPIndex-Proxy
 main: com.pvpindex.bungeecord.PvPIndexBungeePlugin
-version: "1.0.3"
+version: "1.0.4"
 author: PvPIndex Team
 description: Cross-server battle tracking and coordination for PvPIndex (BungeeCord)

--- a/bootstrap-paper/pom.xml
+++ b/bootstrap-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -22,6 +22,7 @@ import com.pvpindex.battles.gamemode.KitApplier;
 import com.pvpindex.battles.identifier.WorldIdentifier;
 import com.pvpindex.battles.identifier.WorldNormalizer;
 import com.pvpindex.battles.battle.BattleBatchScheduler;
+import com.pvpindex.battles.listener.BattleCommandBlockListener;
 import com.pvpindex.battles.listener.BattleEventListener;
 import com.pvpindex.battles.listener.BattleGuiListener;
 import com.pvpindex.battles.listener.ProxyMessageListener;
@@ -240,6 +241,11 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(battleEventListener, this);
 		getServer().getPluginManager().registerEvents(new ModerationListener(moderationService, messageService), this);
 		getServer().getPluginManager().registerEvents(new SetupListener(this, configManager, messageService), this);
+		if (configManager.settings().blockCommandsInBattle()) {
+			getServer().getPluginManager().registerEvents(
+					new BattleCommandBlockListener(battleService, configManager.settings(), messageService), this);
+			getLogger().info("Command blocking during battles enabled.");
+		}
 		getServer().getPluginManager().registerEvents(
 				new WorldCleanupListener(this, battleService, velocityTracker), this);
 

--- a/bootstrap-paper/src/main/resources/config.yml
+++ b/bootstrap-paper/src/main/resources/config.yml
@@ -207,6 +207,22 @@ proxy:
   # How often (in ticks) to send a heartbeat to the proxy (0 to disable).
   heartbeat_interval_ticks: 200
 
+# ─── Command blocking during battles ─────────────────────────────────────────
+# Prevents players from running commands while in an active battle.
+# Players with pvpindex.battle.commands.bypass can still use all commands.
+# Required when the API is enabled to prevent abuse.
+battle_commands:
+  # Set to true to block commands during battles (default).
+  block_commands: true
+  # Commands that are always allowed, even during a battle.
+  # Only the root command is checked (e.g. "battle" matches /battle leave).
+  allowed_commands:
+    - "battle"
+    - "msg"
+    - "r"
+    - "reply"
+    - "tell"
+
 # ─── TeamsAPI guard ───────────────────────────────────────────────────────────
 # Optional integration with TeamsAPI (https://modrinth.com/plugin/teams-api).
 # When enabled, players on the same team cannot challenge each other.

--- a/bootstrap-paper/src/main/resources/lang/de.yml
+++ b/bootstrap-paper/src/main/resources/lang/de.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&cKampf angefochten: %uuid%"
   not_found: "&cKampf nicht gefunden."
   started_good_luck: "&eDer Kampf hat begonnen! Viel Glueck!"
+  command_blocked: "&cBefehle sind waehrend des Kampfes deaktiviert."
 
 queue:
   joined: "&aDer &e%mode%&a-Warteschlange beigetreten. Position: &f%pos%"

--- a/bootstrap-paper/src/main/resources/lang/en.yml
+++ b/bootstrap-paper/src/main/resources/lang/en.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&cBattle disputed: %uuid%"
   not_found: "&cBattle not found."
   started_good_luck: "&eBattle started! Good luck."
+  command_blocked: "&cCommands are disabled during battle."
 
 queue:
   joined: "&aJoined the &e%mode% &aqueue. Position: &f%pos%"

--- a/bootstrap-paper/src/main/resources/lang/es.yml
+++ b/bootstrap-paper/src/main/resources/lang/es.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&cBatalla disputada: %uuid%"
   not_found: "&cBatalla no encontrada."
   started_good_luck: "&eLa batalla ha comenzado. Buena suerte!"
+  command_blocked: "&cLos comandos estan deshabilitados durante la batalla."
 
 queue:
   joined: "&aTe uniste a la cola de &e%mode%&a. Posicion: &f%pos%"

--- a/bootstrap-paper/src/main/resources/lang/nl.yml
+++ b/bootstrap-paper/src/main/resources/lang/nl.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&cGevecht betwist: %uuid%"
   not_found: "&cGevecht niet gevonden."
   started_good_luck: "&eHet gevecht is begonnen! Succes!"
+  command_blocked: "&cCommando's zijn uitgeschakeld tijdens een gevecht."
 
 queue:
   joined: "&aJe bent toegevoegd aan de &e%mode% &awachtrij. Positie: &f%pos%"

--- a/bootstrap-paper/src/main/resources/lang/pl.yml
+++ b/bootstrap-paper/src/main/resources/lang/pl.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&cWalka zakwestionowana: %uuid%"
   not_found: "&cNie znaleziono walki."
   started_good_luck: "&eWalka rozpoczeta! Powodzenia!"
+  command_blocked: "&cKomendy sa wylaczone podczas walki."
 
 queue:
   joined: "&aDolaczono do kolejki &e%mode%&a. Pozycja: &f%pos%"

--- a/bootstrap-paper/src/main/resources/lang/zh.yml
+++ b/bootstrap-paper/src/main/resources/lang/zh.yml
@@ -19,6 +19,7 @@ battle:
   disputed: "&c战斗已申诉: %uuid%"
   not_found: "&c未找到战斗。"
   started_good_luck: "&e战斗开始！祝你好运！"
+  command_blocked: "&c战斗期间不能使用命令。"
 
 queue:
   joined: "&a已加入 &e%mode% &a队列。位置: &f%pos%"

--- a/bootstrap-paper/src/main/resources/plugin.yml
+++ b/bootstrap-paper/src/main/resources/plugin.yml
@@ -48,3 +48,6 @@ permissions:
   pvpindex.battle.queue:
     description: Allows players to use /battle to join matchmaking queues
     default: true
+  pvpindex.battle.commands.bypass:
+    description: Bypass command blocking during active battles
+    default: op

--- a/bootstrap-velocity/pom.xml
+++ b/bootstrap-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-velocity/src/main/resources/velocity-plugin.json
+++ b/bootstrap-velocity/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
 	"id": "pvpindex-proxy",
 	"name": "PvPIndex Proxy",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Cross-server battle tracking and coordination for PvPIndex",
 	"authors": ["PvPIndex Team"],
 	"main": "com.pvpindex.velocity.PvPIndexVelocityPlugin",

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/com/pvpindex/battles/config/PluginSettings.java
+++ b/common/src/main/java/com/pvpindex/battles/config/PluginSettings.java
@@ -3,6 +3,7 @@ package com.pvpindex.battles.config;
 import com.pvpindex.battles.battle.type.BattleType;
 import com.pvpindex.battles.battle.type.GameModeType;
 import com.pvpindex.battles.replay.ReplayDetailLevel;
+import java.util.List;
 import java.util.Set;
 
 public record PluginSettings(
@@ -40,5 +41,8 @@ public record PluginSettings(
         String proxySecret,
         int proxyHeartbeatIntervalTicks,
         // TeamsAPI guard
-        boolean teamsGuardEnabled
+        boolean teamsGuardEnabled,
+        // Command blocking during battles
+        boolean blockCommandsInBattle,
+        List<String> allowedBattleCommands
 ) {}

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -114,4 +114,5 @@ All permissions default to `op` unless noted otherwise.
 | `pvpindex.mod.ban.federated` | op | Federated cross-server bans |
 | `pvpindex.mod.report` | true | Submit reports |
 | `pvpindex.party` | true | Party commands (create, invite, join, leave, kick, disband) |
+| `pvpindex.battle.commands.bypass` | op | Bypass command blocking during active battles |
 | `pvpindex.stats` | true | View stats, history, and leaderboards |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,6 +158,15 @@ When `lobby.enabled` is `true`, the server starts `LobbyNetworkService` and its 
 
 When `database.enabled` is `false` (the default), stats, history, and leaderboard data are not persisted.
 
+### Battle Commands
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `battle_commands.block_commands` | boolean | `true` | Block all commands while a player is in an active battle |
+| `battle_commands.allowed_commands` | List | `[battle, msg, r, reply, tell]` | Commands that are always allowed during a battle (root command only, without `/`) |
+
+Players with `pvpindex.battle.commands.bypass` can use all commands regardless of this setting.
+
 ### Debug
 
 | Key | Type | Default | Description |

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.1.21.x/pom.xml
+++ b/paper-versions/paper.1.21.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.26.1.x/pom.xml
+++ b/paper-versions/paper.26.1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform-bungeecord/pom.xml
+++ b/platform-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/pom.xml
+++ b/platform-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/config/ConfigManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/config/ConfigManager.java
@@ -73,7 +73,12 @@ public class ConfigManager {
 				cfg.getString("proxy.secret", ""),
 				Math.max(1, cfg.getInt("proxy.heartbeat_interval_ticks", 200)),
 				// TeamsAPI guard
-				cfg.getBoolean("teams_guard.block_same_team", false)
+				cfg.getBoolean("teams_guard.block_same_team", false),
+				// Command blocking during battles
+				cfg.getBoolean("battle_commands.block_commands", true),
+				cfg.getStringList("battle_commands.allowed_commands").stream()
+						.map(s -> s.toLowerCase().startsWith("/") ? s.substring(1).toLowerCase() : s.toLowerCase())
+						.toList()
 		);
 
         replaySettings = new ReplaySettings(

--- a/platform-paper/src/main/java/com/pvpindex/battles/listener/BattleCommandBlockListener.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/listener/BattleCommandBlockListener.java
@@ -1,0 +1,69 @@
+package com.pvpindex.battles.listener;
+
+import com.pvpindex.battles.battle.BattleService;
+import com.pvpindex.battles.config.PluginSettings;
+import com.pvpindex.battles.util.MessageService;
+import java.util.List;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+/**
+ * Blocks command execution while a player is in an active battle.
+ * Configurable via {@code battle_commands} in config.yml.
+ * Players with {@code pvpindex.battle.commands.bypass} skip the check.
+ */
+public class BattleCommandBlockListener implements Listener {
+
+    private static final String BYPASS_PERMISSION = "pvpindex.battle.commands.bypass";
+
+    private final BattleService battleService;
+    private final PluginSettings settings;
+    private final MessageService messageService;
+
+    public BattleCommandBlockListener(BattleService battleService, PluginSettings settings, MessageService messageService) {
+        this.battleService = battleService;
+        this.settings = settings;
+        this.messageService = messageService;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        if (!settings.blockCommandsInBattle()) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+
+        if (player.hasPermission(BYPASS_PERMISSION)) {
+            return;
+        }
+
+        if (!battleService.hasActiveBattle(player.getUniqueId())) {
+            return;
+        }
+
+        String raw = event.getMessage().substring(1).trim();
+        String rootCommand = raw.contains(" ") ? raw.substring(0, raw.indexOf(' ')) : raw;
+        rootCommand = rootCommand.toLowerCase();
+
+        if (isAllowed(rootCommand)) {
+            return;
+        }
+
+        event.setCancelled(true);
+        messageService.send(player, "battle.command_blocked");
+    }
+
+    private boolean isAllowed(String rootCommand) {
+        List<String> allowed = settings.allowedBattleCommands();
+        for (String cmd : allowed) {
+            if (cmd.equals(rootCommand)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/platform-paper/src/test/java/com/pvpindex/battles/BattleBatchSchedulerTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/BattleBatchSchedulerTest.java
@@ -162,7 +162,8 @@ class BattleBatchSchedulerTest {
                 false, 40, 20,
                 100,
                 false, "", 0,
-                false
+                false,
+                true, java.util.List.of("battle")
         );
     }
 

--- a/platform-paper/src/test/java/com/pvpindex/battles/BattleServiceTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/BattleServiceTest.java
@@ -80,7 +80,9 @@ class BattleServiceTest {
                 // proxy
                 false, "", 0,
                 // teams guard
-                false
+                false,
+                // command blocking
+                true, java.util.List.of("battle")
         );
         BattleReplayRecorder recorder = new BattleReplayRecorder(plugin, new ObjectMapper(), ReplayDetailLevel.HIGH);
         PvPIndexApiClient apiClient = new PvPIndexApiClient(settings, new ObjectMapper()) {

--- a/platform-paper/src/test/java/com/pvpindex/battles/PacketCaptureWiringTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/PacketCaptureWiringTest.java
@@ -176,7 +176,8 @@ class PacketCaptureWiringTest {
                 false, 40, 20,
                 100,
                 false, "", 0,
-                false
+                false,
+                true, java.util.List.of("battle")
         );
     }
 }

--- a/platform-velocity/pom.xml
+++ b/platform-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.pvpindex</groupId>
     <artifactId>pvpindex-parent</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
 
     <name>PvPIndex Parent</name>


### PR DESCRIPTION
## Summary
- Adds configurable command blocking during active battles, closing #19.
- Players in battle have commands blocked by default. A whitelist (`/battle`, `/msg`, `/r`, `/reply`, `/tell`) allows specific commands through.
- Players with `pvpindex.battle.commands.bypass` permission can still use all commands.

## Changes
- New `BattleCommandBlockListener` intercepting `PlayerCommandPreprocessEvent` at `LOWEST` priority
- New `battle_commands` config section with `block_commands` toggle and `allowed_commands` whitelist
- New `pvpindex.battle.commands.bypass` permission (default: op)
- New `battle.command_blocked` lang key in all 6 language files (en, de, nl, es, pl, zh)
- Version bumped to 1.0.4 across all modules
- Updated tests to include new `PluginSettings` fields

## Test plan
- [ ] Verify commands are blocked during battle
- [ ] Verify whitelisted commands work during battle
- [ ] Verify bypass permission grants full access
- [ ] Verify commands work normally outside battle
- [ ] Verify `block_commands: false` disables the feature
- [ ] CI passes