### PR TITLE
feat: add /pvp alias and leaderboard GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
+## [1.0.5] - 2026-05-22
+
+### Added
+- **`/pvp` alias**: `/pvp` now works as an alias for `/battle`, making it easier for players to discover the command.
+- **Leaderboard GUI** (`/battle leaderboard [mode]`): paginated inventory GUI showing player skulls ranked by Elo. Each skull displays wins, losses, K/D, streak, and best streak. Supports per-mode filtering (`/battle leaderboard sword`) or an overall view. Aliases: `/battle lb`, `/battle top`. Requires `database.enabled: true` in config.yml.
+- New `LeaderboardGui` class in `platform-paper` with 28-entry pages, arrow-based pagination, and skull-per-player layout.
+- New lang keys `leaderboard.no_data`, `leaderboard.unknown_mode`, `leaderboard.error` in all bundled language files (en, de, nl, es, pl, zh).
+
+---
+
 ## [1.0.4] - 2026-05-22
 
 ### Added
@@ -159,7 +169,8 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
-[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.4...HEAD
+[Unreleased]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.5...HEAD
+[1.0.5]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/PVP-Index/pvpindex-battles/compare/v1.0.1...v1.0.2

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ mvn clean package
 
 Output:
 
-- `bootstrap-paper/target/PvPIndexBattles-1.0.4.jar` - drop into Paper `plugins/`
-- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.0.4.jar` - drop into Velocity `plugins/`
-- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.0.4.jar` - drop into BungeeCord `plugins/`
+- `bootstrap-paper/target/PvPIndexBattles-1.0.5.jar` - drop into Paper `plugins/`
+- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.0.5.jar` - drop into Velocity `plugins/`
+- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.0.5.jar` - drop into BungeeCord `plugins/`
 
 The Paper JAR auto-detects your server version (1.21.x or 26.1.x) at startup. No manual configuration needed for version selection.
 
@@ -81,7 +81,7 @@ pvpindex-parent
 - **Moderation** with reports, local bans, and federated network-wide bans
 - **Party system** with create, invite, join, leave, kick, and disband
 - **Persistent database** support (MySQL, SQLite, MongoDB) for player stats, battle history, and leaderboards
-- **Stats and leaderboards**: `/stats`, `/history`, `/leaderboard` commands with per-mode breakdowns
+- **Stats and leaderboards**: `/stats`, `/history`, `/battle leaderboard` GUI with player skulls, Elo, K/D, and pagination
 - **Cross-server coordination** via lobby Redis or proxy plugin messaging with visible error logging
 - **Multi-proxy networking** via Redis Pub/Sub for unlimited proxy instances across regions
 - **PlaceholderAPI** integration for Elo, rank, win/loss, battle state, and battle type

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/pom.xml
+++ b/bootstrap-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/src/main/resources/bungee.yml
+++ b/bootstrap-bungeecord/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: PvPIndex-Proxy
 main: com.pvpindex.bungeecord.PvPIndexBungeePlugin
-version: "1.0.4"
+version: "1.0.5"
 author: PvPIndex Team
 description: Cross-server battle tracking and coordination for PvPIndex (BungeeCord)

--- a/bootstrap-paper/pom.xml
+++ b/bootstrap-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -22,6 +22,7 @@ import com.pvpindex.battles.gamemode.KitApplier;
 import com.pvpindex.battles.identifier.WorldIdentifier;
 import com.pvpindex.battles.identifier.WorldNormalizer;
 import com.pvpindex.battles.battle.BattleBatchScheduler;
+import com.pvpindex.battles.gui.LeaderboardGui;
 import com.pvpindex.battles.listener.BattleCommandBlockListener;
 import com.pvpindex.battles.listener.BattleEventListener;
 import com.pvpindex.battles.listener.BattleGuiListener;
@@ -356,6 +357,12 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		if (teamsGuard.isEnabled()) {
 			getLogger().info("TeamsAPI guard enabled: same-team challenges will be blocked.");
 		}
+		if (dataService != null && dataService.isActive()) {
+			LeaderboardGui leaderboardGui = new LeaderboardGui(this, dataService, gameModeRegistry, messageService);
+			battleGuiCommand.setLeaderboardGui(leaderboardGui);
+			getLogger().info("Leaderboard GUI enabled (database active).");
+		}
+
 		battleGuiCommand.setChallengeManager(challengeManager);
 		battleGuiListener.setChallengeManager(challengeManager);
 		if (proxyMessageListener != null) {

--- a/bootstrap-paper/src/main/resources/lang/de.yml
+++ b/bootstrap-paper/src/main/resources/lang/de.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  Schritt 3 - Neu laden"
   step3_desc: "&7  Fuehre &f/pvpindex reload&7 aus um alle Aenderungen anzuwenden."
   step3_hint: "&7  Spieler koennen dann &f/battle&7 verwenden um die Kampfmodus-GUI zu oeffnen."
+
+leaderboard:
+  no_data: "&cBestenliste nicht verfuegbar. Datenbank ist moeglicherweise deaktiviert."
+  unknown_mode: "&cUnbekannter Spielmodus: %mode%"
+  error: "&cFehler beim Laden der Bestenliste. Versuche es spaeter erneut."

--- a/bootstrap-paper/src/main/resources/lang/en.yml
+++ b/bootstrap-paper/src/main/resources/lang/en.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  Step 3 - Reload"
   step3_desc: "&7  Run &f/pvpindex reload&7 to apply all changes."
   step3_hint: "&7  Players can then use &f/battle&7 to open the battle-mode queue GUI."
+
+leaderboard:
+  no_data: "&cLeaderboard data is not available. Database may be disabled."
+  unknown_mode: "&cUnknown game mode: %mode%"
+  error: "&cFailed to load leaderboard data. Try again later."

--- a/bootstrap-paper/src/main/resources/lang/es.yml
+++ b/bootstrap-paper/src/main/resources/lang/es.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  Paso 3 - Recargar"
   step3_desc: "&7  Ejecuta &f/pvpindex reload&7 para aplicar todos los cambios."
   step3_hint: "&7  Los jugadores pueden usar &f/battle&7 para abrir la GUI de modos de batalla."
+
+leaderboard:
+  no_data: "&cClasificacion no disponible. La base de datos puede estar desactivada."
+  unknown_mode: "&cModo de juego desconocido: %mode%"
+  error: "&cError al cargar la clasificacion. Intentalo mas tarde."

--- a/bootstrap-paper/src/main/resources/lang/nl.yml
+++ b/bootstrap-paper/src/main/resources/lang/nl.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  Stap 3 - Herladen"
   step3_desc: "&7  Voer &f/pvpindex reload&7 uit om alle wijzigingen toe te passen."
   step3_hint: "&7  Spelers kunnen vervolgens &f/battle&7 gebruiken om de gevechtsmodus-GUI te openen."
+
+leaderboard:
+  no_data: "&cRanglijst niet beschikbaar. Database is mogelijk uitgeschakeld."
+  unknown_mode: "&cOnbekende spelmodus: %mode%"
+  error: "&cKan ranglijst niet laden. Probeer het later opnieuw."

--- a/bootstrap-paper/src/main/resources/lang/pl.yml
+++ b/bootstrap-paper/src/main/resources/lang/pl.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  Krok 3 - Przeladuj"
   step3_desc: "&7  Wykonaj &f/pvpindex reload&7 aby zastosowac wszystkie zmiany."
   step3_hint: "&7  Gracze moga nastepnie uzyc &f/battle&7 aby otworzyc GUI trybow walki."
+
+leaderboard:
+  no_data: "&cRanking niedostepny. Baza danych moze byc wylaczona."
+  unknown_mode: "&cNieznany tryb gry: %mode%"
+  error: "&cBlad podczas ladowania rankingu. Sprobuj ponownie pozniej."

--- a/bootstrap-paper/src/main/resources/lang/zh.yml
+++ b/bootstrap-paper/src/main/resources/lang/zh.yml
@@ -136,3 +136,8 @@ setup:
   step3_heading: "&e  步骤 3 - 重新加载"
   step3_desc: "&7  执行 &f/pvpindex reload&7 应用所有更改。"
   step3_hint: "&7  玩家可以使用 &f/battle&7 打开战斗模式选择界面。"
+
+leaderboard:
+  no_data: "&c排行榜数据不可用。数据库可能未启用。"
+  unknown_mode: "&c未知游戏模式: %mode%"
+  error: "&c加载排行榜失败，请稍后重试。"

--- a/bootstrap-paper/src/main/resources/plugin.yml
+++ b/bootstrap-paper/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: PvPIndexBattles
-version: 1.0.4
+version: 1.0.5
 main: com.pvpindex.battles.PvPIndexBattlesPlugin
 api-version: '1.21'
 folia-supported: true
@@ -15,7 +15,8 @@ commands:
     permission: pvpindex.mod
   battle:
     description: Battle GUI, queue, challenges, and forfeit
-    usage: /battle [leave|challenge <player> [mode]|accept <id>|decline <id>]
+    usage: /battle [leave|challenge <player> [mode]|accept <id>|decline <id>|leaderboard [mode]]
+    aliases: [pvp]
     permission: pvpindex.battle.queue
 permissions:
   pvpindex.admin:

--- a/bootstrap-velocity/pom.xml
+++ b/bootstrap-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-velocity/src/main/resources/velocity-plugin.json
+++ b/bootstrap-velocity/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
 	"id": "pvpindex-proxy",
 	"name": "PvPIndex Proxy",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Cross-server battle tracking and coordination for PvPIndex",
 	"authors": ["PvPIndex Team"],
 	"main": "com.pvpindex.velocity.PvPIndexVelocityPlugin",

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,7 +13,7 @@ Root command for PvPIndex administration.
 | `sync` | `pvpindex.admin` | Sync unsubmitted battles to the API |
 | `retryfailed` | `pvpindex.admin` | Retry failed battle submissions |
 
-### /battle
+### /battle (alias: /pvp)
 Player-facing battle queue and challenge commands.
 
 | Subcommand | Permission | Description |
@@ -23,6 +23,7 @@ Player-facing battle queue and challenge commands.
 | `challenge <player> [mode]` | `pvpindex.battle.queue` | Challenge a player to a duel. If mode is omitted, opens the GUI for mode selection |
 | `accept <id>` | `pvpindex.battle.queue` | Accept an incoming challenge |
 | `decline <id>` | `pvpindex.battle.queue` | Decline an incoming challenge |
+| `leaderboard [mode]` | `pvpindex.battle.queue` | Open the leaderboard GUI. Optionally filter by mode (e.g. `sword`, `pot`). Aliases: `lb`, `top`. Requires database. |
 
 ### /pvpmod
 Moderator tools for watching, replaying, reporting, and banning.

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.1.21.x/pom.xml
+++ b/paper-versions/paper.1.21.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.26.1.x/pom.xml
+++ b/paper-versions/paper.26.1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform-bungeecord/pom.xml
+++ b/platform-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/pom.xml
+++ b/platform-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/command/BattleGuiCommand.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/command/BattleGuiCommand.java
@@ -6,6 +6,7 @@ import com.pvpindex.battles.challenge.ChallengeManager;
 import com.pvpindex.battles.gamemode.GameModeDefinition;
 import com.pvpindex.battles.gamemode.GameModeRegistry;
 import com.pvpindex.battles.gui.GuiConfig;
+import com.pvpindex.battles.gui.LeaderboardGui;
 import com.pvpindex.battles.gui.PlayerGuiState;
 import com.pvpindex.battles.queue.BattleQueueService;
 import com.pvpindex.battles.util.MessageService;
@@ -50,6 +51,7 @@ public class BattleGuiCommand implements CommandExecutor {
 	private final GuiConfig guiConfig;
 	private final MessageService messageService;
 	private ChallengeManager challengeManager;
+	private LeaderboardGui leaderboardGui;
 
 	private final Map<UUID, PlayerGuiState> guiStates = new ConcurrentHashMap<>();
 	private final NamespacedKey modeKey;
@@ -69,6 +71,12 @@ public class BattleGuiCommand implements CommandExecutor {
 	public void setChallengeManager(ChallengeManager challengeManager) {
 		this.challengeManager = challengeManager;
 	}
+
+	public void setLeaderboardGui(LeaderboardGui leaderboardGui) {
+		this.leaderboardGui = leaderboardGui;
+	}
+
+	public LeaderboardGui leaderboardGui() { return leaderboardGui; }
 
 	public Map<UUID, PlayerGuiState> guiStates() { return guiStates; }
 	public NamespacedKey modeKey() { return modeKey; }
@@ -91,11 +99,12 @@ public class BattleGuiCommand implements CommandExecutor {
 		}
 
 		return switch (args[0].toLowerCase()) {
-			case "leave"     -> handleLeave(player);
-			case "challenge" -> handleChallenge(player, args);
-			case "accept"    -> handleAccept(player, args);
-			case "decline"   -> handleDecline(player, args);
-			default          -> false;
+			case "leave"        -> handleLeave(player);
+			case "challenge"    -> handleChallenge(player, args);
+			case "accept"       -> handleAccept(player, args);
+			case "decline"      -> handleDecline(player, args);
+			case "leaderboard", "lb", "top" -> handleLeaderboard(player, args);
+			default             -> false;
 		};
 	}
 
@@ -158,6 +167,16 @@ public class BattleGuiCommand implements CommandExecutor {
 		} catch (IllegalArgumentException e) {
 			messageService.send(player, "challenge.invalid_id");
 		}
+		return true;
+	}
+
+	private boolean handleLeaderboard(Player player, String[] args) {
+		if (leaderboardGui == null) {
+			messageService.send(player, "leaderboard.no_data");
+			return true;
+		}
+		String modeId = args.length >= 2 ? args[1] : null;
+		leaderboardGui.open(player, modeId);
 		return true;
 	}
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/command/BattleTabCompleter.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/command/BattleTabCompleter.java
@@ -27,7 +27,7 @@ import org.bukkit.entity.Player;
  */
 public final class BattleTabCompleter implements TabCompleter {
 
-	private static final List<String> SUBS = List.of("leave", "challenge", "accept", "decline");
+	private static final List<String> SUBS = List.of("leave", "challenge", "accept", "decline", "leaderboard");
 
 	private final GameModeRegistry gameModeRegistry;
 	private final ChallengeManager challengeManager;
@@ -77,6 +77,15 @@ public final class BattleTabCompleter implements TabCompleter {
 						.map(m -> m.id())
 						.toList();
 				return filter(modeIds, args[2]);
+			}
+		}
+
+		if (("leaderboard".equals(sub) || "lb".equals(sub) || "top".equals(sub)) && args.length == 2) {
+			if (gameModeRegistry != null) {
+				List<String> modes = new ArrayList<>();
+				modes.add("overall");
+				gameModeRegistry.allModes().stream().map(m -> m.id()).forEach(modes::add);
+				return filter(modes, args[1]);
 			}
 		}
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/gui/LeaderboardGui.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/gui/LeaderboardGui.java
@@ -1,0 +1,242 @@
+package com.pvpindex.battles.gui;
+
+import com.pvpindex.battles.data.DataService;
+import com.pvpindex.battles.gamemode.GameModeRegistry;
+import com.pvpindex.battles.util.MessageService;
+import com.pvpindex.database.model.PlayerStats;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Paginated leaderboard GUI showing player skulls ranked by Elo.
+ * Uses the local database ({@link DataService}) as the data source.
+ */
+public final class LeaderboardGui {
+
+	public static final String TITLE_PREFIX = "\u00a78\u2694 \u00a7fLeaderboard";
+	private static final int ROWS = 6;
+	private static final int SIZE = ROWS * 9;
+	private static final int SLOTS_PER_PAGE = 28;
+	private static final int SLOT_START = 10;
+	private static final int CLOSE_SLOT = 49;
+	private static final int PREV_SLOT = 45;
+	private static final int NEXT_SLOT = 53;
+	private static final int INFO_SLOT = 4;
+
+	private final JavaPlugin plugin;
+	private final DataService dataService;
+	private final GameModeRegistry gameModeRegistry;
+	private final MessageService messageService;
+	private final NamespacedKey pageKey;
+	private final NamespacedKey modeKey;
+
+	private final Map<UUID, Session> sessions = new ConcurrentHashMap<>();
+
+	public LeaderboardGui(JavaPlugin plugin, DataService dataService,
+			GameModeRegistry gameModeRegistry, MessageService messageService) {
+		this.plugin = plugin;
+		this.dataService = dataService;
+		this.gameModeRegistry = gameModeRegistry;
+		this.messageService = messageService;
+		this.pageKey = new NamespacedKey(plugin, "lb_page");
+		this.modeKey = new NamespacedKey(plugin, "lb_mode");
+	}
+
+	public Map<UUID, Session> sessions() { return sessions; }
+
+	public void open(Player player, String modeId) {
+		if (dataService == null || !dataService.isActive()) {
+			messageService.send(player, "leaderboard.no_data");
+			return;
+		}
+
+		String resolvedMode = modeId != null ? modeId.toLowerCase() : "overall";
+		if (!"overall".equals(resolvedMode) && gameModeRegistry.findMode(resolvedMode).isEmpty()) {
+			messageService.send(player, "leaderboard.unknown_mode", "%mode%", resolvedMode);
+			return;
+		}
+
+		sessions.put(player.getUniqueId(), new Session(resolvedMode, 0));
+		loadPage(player, resolvedMode, 0);
+	}
+
+	public void loadPage(Player player, String modeId, int page) {
+		int offset = page * SLOTS_PER_PAGE;
+		int fetchLimit = SLOTS_PER_PAGE + 1;
+
+		dataService.provider().statsRepository()
+				.getLeaderboard(modeId, "elo", fetchLimit + offset)
+				.thenAccept(allStats -> {
+					List<PlayerStats> pageStats = allStats.size() > offset
+							? allStats.subList(offset, Math.min(allStats.size(), offset + SLOTS_PER_PAGE))
+							: List.of();
+					boolean hasNextPage = allStats.size() > offset + SLOTS_PER_PAGE;
+
+					Bukkit.getScheduler().runTask(plugin, () -> {
+						String displayMode = gameModeRegistry.findMode(modeId)
+								.map(m -> m.displayName())
+								.orElse(capitalise(modeId));
+						String title = TITLE_PREFIX + " \u00a77- \u00a7e" + displayMode;
+						Inventory inv = Bukkit.createInventory(null, SIZE, title);
+
+						ItemStack filler = GUIBuilder.glassPane(Material.BLACK_STAINED_GLASS_PANE);
+						for (int i = 0; i < SIZE; i++) {
+							inv.setItem(i, filler);
+						}
+
+						buildInfoItem(inv, displayMode, page, pageStats.size(), offset);
+						buildEntries(inv, pageStats, offset);
+						buildNavigation(inv, page, hasNextPage, modeId);
+						buildCloseItem(inv);
+
+						sessions.put(player.getUniqueId(), new Session(modeId, page));
+						player.openInventory(inv);
+					});
+				})
+				.exceptionally(ex -> {
+					Bukkit.getScheduler().runTask(plugin, () ->
+							messageService.send(player, "leaderboard.error"));
+					return null;
+				});
+	}
+
+	private void buildInfoItem(Inventory inv, String displayMode, int page,
+			int entryCount, int offset) {
+		ItemStack item = new ItemStack(Material.NETHER_STAR);
+		ItemMeta meta = item.getItemMeta();
+		if (meta != null) {
+			meta.setDisplayName(ChatColor.GOLD + "" + ChatColor.BOLD + displayMode + " Leaderboard");
+			List<String> lore = new ArrayList<>();
+			lore.add(ChatColor.GRAY + "Page " + (page + 1));
+			if (entryCount > 0) {
+				lore.add(ChatColor.GRAY + "Showing #" + (offset + 1) + " - #" + (offset + entryCount));
+			} else {
+				lore.add(ChatColor.GRAY + "No entries found.");
+			}
+			meta.setLore(lore);
+			meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+			item.setItemMeta(meta);
+		}
+		inv.setItem(INFO_SLOT, item);
+	}
+
+	private void buildEntries(Inventory inv, List<PlayerStats> entries, int offset) {
+		int[] slots = computeSlots();
+		for (int i = 0; i < entries.size() && i < slots.length; i++) {
+			PlayerStats stats = entries.get(i);
+			int rank = offset + i + 1;
+			ItemStack skull = buildPlayerSkull(stats, rank);
+			inv.setItem(slots[i], skull);
+		}
+	}
+
+	private ItemStack buildPlayerSkull(PlayerStats stats, int rank) {
+		ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+		SkullMeta meta = (SkullMeta) skull.getItemMeta();
+		if (meta != null) {
+			String playerName = resolvePlayerName(stats.uuid());
+			meta.setOwningPlayer(Bukkit.getOfflinePlayer(stats.uuid()));
+
+			ChatColor rankColour = rank <= 3 ? ChatColor.GOLD : ChatColor.YELLOW;
+			meta.setDisplayName(rankColour + "#" + rank + " " + ChatColor.WHITE + playerName);
+
+			List<String> lore = new ArrayList<>();
+			lore.add("");
+			lore.add(ChatColor.GRAY + "Elo: " + ChatColor.AQUA + stats.elo());
+			lore.add(ChatColor.GRAY + "Wins: " + ChatColor.GREEN + stats.wins());
+			lore.add(ChatColor.GRAY + "Losses: " + ChatColor.RED + stats.losses());
+			if (stats.deaths() > 0) {
+				double kd = (double) stats.kills() / stats.deaths();
+				lore.add(ChatColor.GRAY + "K/D: " + ChatColor.WHITE + String.format("%.2f", kd));
+			} else {
+				lore.add(ChatColor.GRAY + "K/D: " + ChatColor.WHITE + stats.kills() + ".00");
+			}
+			lore.add(ChatColor.GRAY + "Streak: " + ChatColor.WHITE + stats.streak());
+			lore.add(ChatColor.GRAY + "Best Streak: " + ChatColor.WHITE + stats.bestStreak());
+			lore.add("");
+			lore.add(ChatColor.DARK_GRAY + "Mode: " + stats.modeId());
+			meta.setLore(lore);
+			meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+			skull.setItemMeta(meta);
+		}
+		return skull;
+	}
+
+	private void buildNavigation(Inventory inv, int page, boolean hasNext, String modeId) {
+		if (page > 0) {
+			ItemStack prev = new ItemStack(Material.ARROW);
+			ItemMeta meta = prev.getItemMeta();
+			if (meta != null) {
+				meta.setDisplayName(ChatColor.GREEN + "\u00ab Previous Page");
+				meta.getPersistentDataContainer().set(pageKey, PersistentDataType.INTEGER, page - 1);
+				meta.getPersistentDataContainer().set(this.modeKey, PersistentDataType.STRING, modeId);
+				prev.setItemMeta(meta);
+			}
+			inv.setItem(PREV_SLOT, prev);
+		}
+
+		if (hasNext) {
+			ItemStack next = new ItemStack(Material.ARROW);
+			ItemMeta meta = next.getItemMeta();
+			if (meta != null) {
+				meta.setDisplayName(ChatColor.GREEN + "Next Page \u00bb");
+				meta.getPersistentDataContainer().set(pageKey, PersistentDataType.INTEGER, page + 1);
+				meta.getPersistentDataContainer().set(this.modeKey, PersistentDataType.STRING, modeId);
+				next.setItemMeta(meta);
+			}
+			inv.setItem(NEXT_SLOT, next);
+		}
+	}
+
+	private void buildCloseItem(Inventory inv) {
+		ItemStack item = new ItemStack(Material.BARRIER);
+		ItemMeta meta = item.getItemMeta();
+		if (meta != null) {
+			meta.setDisplayName(ChatColor.DARK_GRAY + "Close");
+			item.setItemMeta(meta);
+		}
+		inv.setItem(CLOSE_SLOT, item);
+	}
+
+	private int[] computeSlots() {
+		List<Integer> slots = new ArrayList<>();
+		for (int row = 1; row <= 4; row++) {
+			int rowStart = row * 9;
+			for (int col = 1; col <= 7; col++) {
+				slots.add(rowStart + col);
+			}
+		}
+		return slots.stream().mapToInt(Integer::intValue).toArray();
+	}
+
+	private String resolvePlayerName(UUID uuid) {
+		Player online = Bukkit.getPlayer(uuid);
+		if (online != null) return online.getName();
+		return Bukkit.getOfflinePlayer(uuid).getName();
+	}
+
+	private static String capitalise(String s) {
+		if (s == null || s.isEmpty()) return s;
+		return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+	}
+
+	public NamespacedKey pageKey() { return pageKey; }
+	public NamespacedKey modeKey() { return modeKey; }
+
+	public record Session(String modeId, int page) {}
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/listener/BattleGuiListener.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/listener/BattleGuiListener.java
@@ -6,6 +6,7 @@ import com.pvpindex.battles.gamemode.GameModeDefinition;
 import com.pvpindex.battles.gamemode.GameModeRegistry;
 import com.pvpindex.battles.gui.GUIBuilder;
 import com.pvpindex.battles.gui.GuiConfig;
+import com.pvpindex.battles.gui.LeaderboardGui;
 import com.pvpindex.battles.gui.PlayerGuiState;
 import com.pvpindex.battles.queue.BattleQueueService;
 import com.pvpindex.battles.util.MessageService;
@@ -69,7 +70,13 @@ public class BattleGuiListener implements Listener {
 			return;
 		}
 
-		if (!guiConfig.battleTitle().equals(event.getView().getTitle())) return;
+		String title = event.getView().getTitle();
+		if (title.startsWith(LeaderboardGui.TITLE_PREFIX)) {
+			handleLeaderboardClick(event, player);
+			return;
+		}
+
+		if (!guiConfig.battleTitle().equals(title)) return;
 
 		event.setCancelled(true);
 
@@ -146,6 +153,29 @@ public class BattleGuiListener implements Listener {
 			} else if (name.equals(challengeLabel) || name.equals(challengeInactiveLabel)) {
 				messageService.send(player, "challenge.gui_hint");
 			}
+		}
+	}
+
+	private void handleLeaderboardClick(InventoryClickEvent event, Player player) {
+		event.setCancelled(true);
+		ItemStack clicked = event.getCurrentItem();
+		if (clicked == null || clicked.getType() == Material.AIR) return;
+
+		if (clicked.getType() == Material.BARRIER) {
+			player.closeInventory();
+			return;
+		}
+
+		LeaderboardGui lbGui = guiCommand.leaderboardGui();
+		if (lbGui == null) return;
+
+		ItemMeta meta = clicked.getItemMeta();
+		if (meta == null) return;
+
+		Integer targetPage = meta.getPersistentDataContainer().get(lbGui.pageKey(), PersistentDataType.INTEGER);
+		String modeId = meta.getPersistentDataContainer().get(lbGui.modeKey(), PersistentDataType.STRING);
+		if (targetPage != null && modeId != null) {
+			lbGui.loadPage(player, modeId, targetPage);
 		}
 	}
 
@@ -226,15 +256,22 @@ public class BattleGuiListener implements Listener {
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
 		if (!(event.getPlayer() instanceof Player player)) return;
-		if (guiConfig.battleTitle().equals(event.getView().getTitle())) {
+		String title = event.getView().getTitle();
+		if (guiConfig.battleTitle().equals(title)) {
 			PlayerGuiState state = guiCommand.guiStates().get(player.getUniqueId());
 			if (state != null && state.pendingConfirmationModeId() != null) {
 				return;
 			}
 			guiCommand.guiStates().remove(player.getUniqueId());
 		}
-		if (guiConfig.confirmationTitle().equals(event.getView().getTitle())) {
+		if (guiConfig.confirmationTitle().equals(title)) {
 			guiCommand.guiStates().remove(player.getUniqueId());
+		}
+		if (title.startsWith(LeaderboardGui.TITLE_PREFIX)) {
+			LeaderboardGui lbGui = guiCommand.leaderboardGui();
+			if (lbGui != null) {
+				lbGui.sessions().remove(player.getUniqueId());
+			}
 		}
 	}
 

--- a/platform-velocity/pom.xml
+++ b/platform-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.pvpindex</groupId>
     <artifactId>pvpindex-parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>pom</packaging>
 
     <name>PvPIndex Parent</name>


### PR DESCRIPTION
## Summary
- `/pvp` now works as an alias for `/battle`.
- New `/battle leaderboard [mode]` subcommand (aliases: `lb`, `top`) opens a paginated GUI showing player skulls ranked by Elo with wins, losses, K/D, streak stats.
- Uses the local database, works on all servers with `database.enabled: true`. No PvPIndex API dependency required.

## Changes
- `/pvp` alias registered in `plugin.yml`
- New `LeaderboardGui` class with 28-entry pages, arrow-based pagination, player skull heads
- `BattleGuiCommand` updated with `leaderboard` subcommand handler
- `BattleTabCompleter` updated with mode tab completion for leaderboard
- `BattleGuiListener` updated with leaderboard click and close handling
- `PvPIndexBattlesPlugin` wires up `LeaderboardGui` when database is active
- New lang keys `leaderboard.no_data`, `leaderboard.unknown_mode`, `leaderboard.error` in all 6 language files
- Version bumped to 1.0.5 across all modules
- Changelog, COMMANDS.md, README.md updated

## Test plan
- [ ] `/pvp` opens the battle GUI
- [ ] `/battle leaderboard` opens paginated skull GUI
- [ ] `/battle leaderboard sword` filters by mode
- [ ] Pagination arrows work correctly
- [ ] Close button works
- [ ] Tab completion suggests mode names
- [ ] Shows "no data" message when database is disabled
- [ ] CI passes