### PR TITLE
feat: add practice mode (reaction training + bot duel)

### DIFF
--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -24,6 +24,11 @@ import com.pvpindex.battles.identifier.WorldNormalizer;
 import com.pvpindex.battles.battle.BattleBatchScheduler;
 import com.pvpindex.battles.gui.LeaderboardGui;
 import com.pvpindex.battles.listener.BattleCommandBlockListener;
+import com.pvpindex.battles.practice.PracticeCommand;
+import com.pvpindex.battles.practice.PracticeManager;
+import com.pvpindex.battles.practice.PracticeSettings;
+import com.pvpindex.battles.practice.PracticeTabCompleter;
+import com.pvpindex.battles.listener.PracticeListener;
 import com.pvpindex.battles.listener.BattleEventListener;
 import com.pvpindex.battles.listener.BattleGuiListener;
 import com.pvpindex.battles.listener.ProxyMessageListener;
@@ -117,6 +122,7 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		saveResourceIfAbsent("gui.yml");
 		saveResourceIfAbsent("templates.yml");
 		saveResourceIfAbsent("schematics.yml");
+		saveResourceIfAbsent("practice.yml");
 		// Bundled schematic files — only written once (never overwrite server-owner edits).
 		saveResourceIfAbsent("schematics/arena.schem");
 		saveResourceIfAbsent("schematics/colosseum.schem");
@@ -361,6 +367,27 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 			LeaderboardGui leaderboardGui = new LeaderboardGui(this, dataService, gameModeRegistry, messageService);
 			battleGuiCommand.setLeaderboardGui(leaderboardGui);
 			getLogger().info("Leaderboard GUI enabled (database active).");
+		}
+
+		// Practice mode — wired after gameModeRegistry and playerStateService are ready
+		org.bukkit.configuration.file.YamlConfiguration practiceYaml =
+				org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(
+						new java.io.File(getDataFolder(), "practice.yml"));
+		PracticeSettings practiceSettings = PracticeSettings.from(practiceYaml);
+		if (practiceSettings.enabled()) {
+			PracticeManager practiceManager = new PracticeManager(
+					this, playerStateService, new KitApplier(versionAdapter),
+					gameModeRegistry, practiceSettings);
+			var practiceCmd = getCommand("practice");
+			if (practiceCmd != null) {
+				PracticeCommand practiceCommand = new PracticeCommand(practiceManager, messageService);
+				practiceCmd.setExecutor(practiceCommand);
+				practiceCmd.setTabCompleter(new PracticeTabCompleter(gameModeRegistry));
+			}
+			battleGuiCommand.setPracticeManager(practiceManager);
+			getServer().getPluginManager().registerEvents(
+					new PracticeListener(practiceManager, battleGuiCommand), this);
+			getLogger().info("Practice mode enabled (/practice).");
 		}
 
 		battleGuiCommand.setChallengeManager(challengeManager);

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -377,7 +377,7 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		if (practiceSettings.enabled()) {
 			PracticeManager practiceManager = new PracticeManager(
 					this, playerStateService, new KitApplier(versionAdapter),
-					gameModeRegistry, practiceSettings);
+					gameModeRegistry, practiceSettings, arenaPoolService);
 			var practiceCmd = getCommand("practice");
 			if (practiceCmd != null) {
 				PracticeCommand practiceCommand = new PracticeCommand(practiceManager, messageService);

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -373,6 +373,8 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		org.bukkit.configuration.file.YamlConfiguration practiceYaml =
 				org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(
 						new java.io.File(getDataFolder(), "practice.yml"));
+		// Load the platform-specific NMS bot adapter (Folia → null, stays Zombie fallback)
+		initBotNmsAdapter(detectMinecraftVersion());
 		PracticeSettings practiceSettings = PracticeSettings.from(practiceYaml);
 		if (practiceSettings.enabled()) {
 			PracticeManager practiceManager = new PracticeManager(
@@ -662,5 +664,68 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 		} catch (ReflectiveOperationException ignored) {}
 
 		return null;
+	}
+
+	/**
+	 * Loads the correct {@link com.pvpindex.battles.practice.bot.BotNmsAdapter} for the
+	 * running platform and registers it with {@link com.pvpindex.battles.practice.bot.BotPlayerFactory}.
+	 *
+	 * <p>Platform routing:</p>
+	 * <ul>
+	 *   <li><b>Folia</b> — NMS entity creation is not safe across region threads; no adapter
+	 *       loaded; {@code BotPlayerFactory} falls back to Zombie for all sessions.</li>
+	 *   <li><b>Paper / Spigot 26.1.x</b> — loads {@code BotNmsAdapter2610} which handles
+	 *       {@code ServerWaypointManager} cleanup on spawn failure.</li>
+	 *   <li><b>Paper / Spigot 1.21.x</b> — loads {@code BotNmsAdapter121}.</li>
+	 * </ul>
+	 *
+	 * <p>Must be called before the first {@link com.pvpindex.battles.practice.bot.BotSession}
+	 * is started (i.e. before {@code PracticeManager} construction).</p>
+	 *
+	 * @param mcVersion the Minecraft version string, e.g. {@code "26.1.2"} or {@code "1.21.4"}
+	 */
+	private void initBotNmsAdapter(String mcVersion) {
+		// Folia: NMS entity creation is not thread-safe across region boundaries.
+		// Keep nmsAdapter null so BotPlayerFactory always uses the Zombie fallback.
+		boolean isFolia = false;
+		try {
+			Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+			isFolia = true;
+		} catch (ClassNotFoundException ignored) {}
+		if (isFolia) {
+			getLogger().info("[PracticeBot] Folia detected — NMS bot disabled; using Zombie fallback.");
+			return;
+		}
+
+		// Paper / Spigot 26.1.x (new versioning scheme: "26.x.y")
+		if (mcVersion.startsWith("26.")) {
+			try {
+				com.pvpindex.battles.practice.bot.BotNmsAdapter adapter =
+						(com.pvpindex.battles.practice.bot.BotNmsAdapter)
+						Class.forName("com.pvpindex.paper.v1_26_1.BotNmsAdapter2610")
+								.getDeclaredConstructor()
+								.newInstance();
+				com.pvpindex.battles.practice.bot.BotPlayerFactory.setNmsAdapter(adapter);
+				getLogger().info("[PracticeBot] NMS bot adapter: BotNmsAdapter2610 (Paper 26.1.x).");
+			} catch (ReflectiveOperationException e) {
+				getLogger().warning("[PracticeBot] Failed to load BotNmsAdapter2610: " + e.getMessage()
+						+ " — NMS bot disabled.");
+			}
+			return;
+		}
+
+		// Paper / Spigot 1.21.x
+		try {
+			com.pvpindex.battles.practice.bot.BotNmsAdapter adapter =
+					(com.pvpindex.battles.practice.bot.BotNmsAdapter)
+					Class.forName("com.pvpindex.paper.v1_21.BotNmsAdapter121")
+							.getDeclaredConstructor()
+							.newInstance();
+			com.pvpindex.battles.practice.bot.BotPlayerFactory.setNmsAdapter(adapter);
+			getLogger().info("[PracticeBot] NMS bot adapter: BotNmsAdapter121 (Paper/Spigot 1.21.x).");
+		} catch (ReflectiveOperationException e) {
+			getLogger().warning("[PracticeBot] Failed to load BotNmsAdapter121: " + e.getMessage()
+					+ " — NMS bot disabled.");
+		}
 	}
 }

--- a/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
+++ b/bootstrap-paper/src/main/java/com/pvpindex/battles/PvPIndexBattlesPlugin.java
@@ -706,7 +706,8 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 								.getDeclaredConstructor()
 								.newInstance();
 				com.pvpindex.battles.practice.bot.BotPlayerFactory.setNmsAdapter(adapter);
-				getLogger().info("[PracticeBot] NMS bot adapter: BotNmsAdapter2610 (Paper 26.1.x).");
+				getLogger().warning("[PracticeBot] [EXPERIMENTAL] NMS fake-player bot loaded: BotNmsAdapter2610 (Paper 26.1.x). "
+					+ "This feature is experimental — set 'use_nms_fake_player: false' to disable.");
 			} catch (ReflectiveOperationException e) {
 				getLogger().warning("[PracticeBot] Failed to load BotNmsAdapter2610: " + e.getMessage()
 						+ " — NMS bot disabled.");
@@ -722,7 +723,8 @@ public class PvPIndexBattlesPlugin extends JavaPlugin {
 							.getDeclaredConstructor()
 							.newInstance();
 			com.pvpindex.battles.practice.bot.BotPlayerFactory.setNmsAdapter(adapter);
-			getLogger().info("[PracticeBot] NMS bot adapter: BotNmsAdapter121 (Paper/Spigot 1.21.x).");
+			getLogger().warning("[PracticeBot] [EXPERIMENTAL] NMS fake-player bot loaded: BotNmsAdapter121 (Paper/Spigot 1.21.x). "
+					+ "This feature is experimental — set 'use_nms_fake_player: false' to disable.");
 		} catch (ReflectiveOperationException e) {
 			getLogger().warning("[PracticeBot] Failed to load BotNmsAdapter121: " + e.getMessage()
 					+ " — NMS bot disabled.");

--- a/bootstrap-paper/src/main/resources/lang/en.yml
+++ b/bootstrap-paper/src/main/resources/lang/en.yml
@@ -141,3 +141,15 @@ leaderboard:
   no_data: "&cLeaderboard data is not available. Database may be disabled."
   unknown_mode: "&cUnknown game mode: %mode%"
   error: "&cFailed to load leaderboard data. Try again later."
+
+
+practice:
+  not_enabled: "&cPractice mode is not enabled on this server."
+  already_in_practice: "&eYou are already in a practice session. Use /practice stop to exit."
+  started_reaction: "&aReaction training started! Hit the glowing targets as fast as you can."
+  started_bot: "&aBot duel started! Defeat the practice bot."
+  stopped: "&ePractice session ended."
+  target_hit: "&aHit! &7Reaction time: &f%time%ms"
+  target_missed: "&cMissed a target!"
+  bot_defeated: "&a&lBot defeated! &r&7Well done."
+  usage: "&cUsage: /practice [reaction|bot|stop] [gameMode]"

--- a/bootstrap-paper/src/main/resources/plugin.yml
+++ b/bootstrap-paper/src/main/resources/plugin.yml
@@ -15,9 +15,13 @@ commands:
     permission: pvpindex.mod
   battle:
     description: Battle GUI, queue, challenges, and forfeit
-    usage: /battle [leave|challenge <player> [mode]|accept <id>|decline <id>|leaderboard [mode]]
+    usage: /battle [leave|challenge <player> [mode]|accept <id>|decline <id>|leaderboard [mode]|practice]
     aliases: [pvp]
     permission: pvpindex.battle.queue
+  practice:
+    description: Enter practice mode (reaction training or bot duel)
+    usage: /practice [reaction|bot|stop] [gameMode]
+    permission: pvpindex.practice
 permissions:
   pvpindex.admin:
     default: op
@@ -52,3 +56,6 @@ permissions:
   pvpindex.battle.commands.bypass:
     description: Bypass command blocking during active battles
     default: op
+  pvpindex.practice:
+    description: Allows players to use the /practice command
+    default: true

--- a/bootstrap-paper/src/main/resources/practice.yml
+++ b/bootstrap-paper/src/main/resources/practice.yml
@@ -47,9 +47,15 @@ practice:
     # Damage dealt per bot hit (3.0 = 1.5 hearts; equivalent to an iron sword).
     attack_damage: 3.0
 
+    # ── EXPERIMENTAL ─────────────────────────────────────────────────────────
     # When true, attempt to spawn an NMS ServerPlayer for a realistic player model.
     # Falls back to a Zombie with equipment if NMS reflection fails.
-    # WARNING: NMS fake-player support is experimental and may crash the server on
-    # some Paper builds.  Keep false unless you have verified NMS support works on
-    # your specific server version.
+    #
+    # Supported platforms:  Paper 1.21.x, Paper 26.1.x, Spigot 1.21.x
+    # Unsupported:          Folia (always uses Zombie fallback regardless of this flag)
+    #
+    # WARNING: This is an EXPERIMENTAL feature.  NMS internals may change between
+    # builds and could produce unexpected behaviour or errors on your server.
+    # A startup warning is printed when this feature is active.
+    # Keep this set to false unless you have tested NMS bot support on your server.
     use_nms_fake_player: false

--- a/bootstrap-paper/src/main/resources/practice.yml
+++ b/bootstrap-paper/src/main/resources/practice.yml
@@ -19,6 +19,20 @@ practice:
     # How long a target stays before counting as a miss (100 = 5 seconds).
     target_lifetime_ticks: 100
 
+    # Spawn mode controls where targets appear:
+    #   arena  (default) — within the flat arena floor; targets stay inside the
+    #                       arena bounds regardless of where the player stands.
+    #   player            — random offsets around the player's eye position
+    #                       (original behaviour; opt-in).
+    spawn_mode: "arena"
+
+    # Radius (blocks) around the arena centre used when spawn_mode is "arena".
+    arena_spawn_radius: 6.0
+
+    # Height range above the arena floor when spawn_mode is "arena" (targets
+    # appear between floor+0.7 and floor+0.7+height_range).
+    arena_spawn_height_range: 1.5
+
   # ── Bot Duel ─────────────────────────────────────────────────────────────────
   bot:
     # Default kit ID from gamemodes.yml to equip the bot (and the player).
@@ -35,4 +49,7 @@ practice:
 
     # When true, attempt to spawn an NMS ServerPlayer for a realistic player model.
     # Falls back to a Zombie with equipment if NMS reflection fails.
-    use_nms_fake_player: true
+    # WARNING: NMS fake-player support is experimental and may crash the server on
+    # some Paper builds.  Keep false unless you have verified NMS support works on
+    # your specific server version.
+    use_nms_fake_player: false

--- a/bootstrap-paper/src/main/resources/practice.yml
+++ b/bootstrap-paper/src/main/resources/practice.yml
@@ -1,0 +1,34 @@
+# ─── PvPIndex Practice Mode Configuration ──────────────────────────────────────
+
+practice:
+  # Set to false to completely disable the /practice command and Practice tab.
+  enabled: true
+
+  # ── Reaction Training ────────────────────────────────────────────────────────
+  reaction_training:
+    # Maximum number of active targets visible at once.
+    max_targets: 5
+
+    # How often (in ticks) a new target is spawned (40 = 2 seconds).
+    spawn_interval_ticks: 40
+
+    # How long a target stays before counting as a miss (100 = 5 seconds).
+    target_lifetime_ticks: 100
+
+  # ── Bot Duel ─────────────────────────────────────────────────────────────────
+  bot:
+    # Default kit ID from gamemodes.yml to equip the bot (and the player).
+    kit_id: "sword_starter"
+
+    # How often (in ticks) the bot deals melee damage to the player (10 = 0.5 s).
+    attack_interval_ticks: 10
+
+    # Movement speed in blocks per tick (0.28 ≈ a sprinting player).
+    move_speed: 0.28
+
+    # Damage dealt per bot hit (3.0 = 1.5 hearts; equivalent to an iron sword).
+    attack_damage: 3.0
+
+    # When true, attempt to spawn an NMS ServerPlayer for a realistic player model.
+    # Falls back to a Zombie with equipment if NMS reflection fails.
+    use_nms_fake_player: true

--- a/bootstrap-paper/src/main/resources/practice.yml
+++ b/bootstrap-paper/src/main/resources/practice.yml
@@ -4,6 +4,10 @@ practice:
   # Set to false to completely disable the /practice command and Practice tab.
   enabled: true
 
+  # Arena template to use for practice sessions (must exist in templates.yml).
+  # Players are teleported to spawn[0]; the bot spawns at spawn[1] for Bot Duel.
+  template_id: "arena_duel"
+
   # ── Reaction Training ────────────────────────────────────────────────────────
   reaction_training:
     # Maximum number of active targets visible at once.

--- a/common/src/main/java/com/pvpindex/battles/practice/PracticeMode.java
+++ b/common/src/main/java/com/pvpindex/battles/practice/PracticeMode.java
@@ -1,0 +1,9 @@
+package com.pvpindex.battles.practice;
+
+/** Identifies which sub-mode of practice a player is running. */
+public enum PracticeMode {
+    /** Hittable particle-target reaction-speed drill. */
+    REACTION_TRAINING,
+    /** 1v1 duel against a scripted NMS fake-player bot. */
+    BOT_DUEL
+}

--- a/common/src/main/java/com/pvpindex/battles/practice/PracticeSession.java
+++ b/common/src/main/java/com/pvpindex/battles/practice/PracticeSession.java
@@ -1,0 +1,29 @@
+package com.pvpindex.battles.practice;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Immutable snapshot of an active practice session.
+ * Created when a player enters any practice mode and discarded when they leave.
+ */
+public final class PracticeSession {
+
+    private final UUID playerUuid;
+    private final PracticeMode mode;
+    /** The game-mode kit ID used for this session (e.g. {@code "sword_starter"}). May be null for default. */
+    private final String gameModeId;
+    private final Instant startedAt;
+
+    public PracticeSession(UUID playerUuid, PracticeMode mode, String gameModeId) {
+        this.playerUuid = playerUuid;
+        this.mode = mode;
+        this.gameModeId = gameModeId;
+        this.startedAt = Instant.now();
+    }
+
+    public UUID playerUuid() { return playerUuid; }
+    public PracticeMode mode() { return mode; }
+    public String gameModeId() { return gameModeId; }
+    public Instant startedAt() { return startedAt; }
+}

--- a/paper-versions/paper.1.21.x/src/main/java/com/pvpindex/paper/v1_21/BotNmsAdapter121.java
+++ b/paper-versions/paper.1.21.x/src/main/java/com/pvpindex/paper/v1_21/BotNmsAdapter121.java
@@ -1,0 +1,88 @@
+package com.pvpindex.paper.v1_21;
+
+import com.pvpindex.battles.practice.bot.BotNmsAdapter;
+import com.pvpindex.battles.practice.bot.NmsSpawnHelper;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * NMS bot adapter for <b>Paper / Spigot 1.21.x</b>.
+ *
+ * <p>Constructs a headless {@code net.minecraft.server.level.ServerPlayer} via
+ * reflection and registers it with the world's entity tracking.  On 1.21.x
+ * {@code ServerWaypointManager} does not exist, so the cleanup path only needs
+ * to call {@code removePlayerImmediately} or {@code setRemoved(DISCARDED)} to
+ * unregister the entity from {@code EntityLookup} and {@code PlayerList}.</p>
+ *
+ * <p>Also works on <b>Spigot 1.21.x</b>: Spigot shares the same NMS class paths
+ * ({@code net.minecraft.server.level.*}) since the removal of versioned packages
+ * in 1.17, so all reflection calls succeed identically.</p>
+ */
+public final class BotNmsAdapter121 implements BotNmsAdapter {
+
+    @Override
+    public LivingEntity spawnFakePlayer(World world, Location location, String name)
+            throws Exception {
+        Object nmsLevel = null;
+        Object bot = null;
+        try {
+            // 1 ── MinecraftServer ─────────────────────────────────────────────
+            Object craftServer = Bukkit.getServer();
+            Object nmsServer = craftServer.getClass()
+                    .getMethod("getServer")
+                    .invoke(craftServer);
+
+            // 2 ── ServerLevel ─────────────────────────────────────────────────
+            nmsLevel = world.getClass()
+                    .getMethod("getHandle")
+                    .invoke(world);
+
+            // 3 ── GameProfile ─────────────────────────────────────────────────
+            UUID botUuid = UUID.nameUUIDFromBytes(
+                    ("PracticeBot:" + name).getBytes(StandardCharsets.UTF_8));
+            Class<?> gpClass = Class.forName("com.mojang.authlib.GameProfile");
+            Object profile = gpClass
+                    .getConstructor(UUID.class, String.class)
+                    .newInstance(botUuid, name);
+
+            // 4 ── ClientInformation.createDefault() ───────────────────────────
+            Object clientInfo = NmsSpawnHelper.resolveClientInformationDefault();
+            if (clientInfo == null) {
+                throw new UnsupportedOperationException(
+                        "ClientInformation.createDefault() not found on 1.21.x");
+            }
+
+            // 5 ── ServerPlayer constructor ────────────────────────────────────
+            Class<?> spClass = Class.forName("net.minecraft.server.level.ServerPlayer");
+            Constructor<?> ctor = NmsSpawnHelper.resolveServerPlayerConstructor(spClass);
+            bot = ctor.newInstance(nmsServer, nmsLevel, profile, clientInfo);
+
+            // 6 ── Set initial position ────────────────────────────────────────
+            bot.getClass()
+                    .getMethod("setPos", double.class, double.class, double.class)
+                    .invoke(bot, location.getX(), location.getY(), location.getZ());
+
+            // 7 ── Add to world ────────────────────────────────────────────────
+            NmsSpawnHelper.addFreshEntityReflective(nmsLevel, bot);
+
+            // 8 ── Wrap as Bukkit entity ───────────────────────────────────────
+            Object bukkit = bot.getClass().getMethod("getBukkitEntity").invoke(bot);
+            if (bukkit instanceof LivingEntity le) return le;
+            throw new IllegalStateException("getBukkitEntity() did not return a LivingEntity");
+
+        } catch (Exception e) {
+            // Ensure the partially-registered entity is removed from EntityLookup
+            // and PlayerList before re-throwing so the caller's Zombie fallback
+            // does not race with a stale null-connection ServerPlayer.
+            if (bot != null) {
+                NmsSpawnHelper.tryRemoveEntity(nmsLevel, bot);
+            }
+            throw e;
+        }
+    }
+}

--- a/paper-versions/paper.26.1.x/src/main/java/com/pvpindex/paper/v1_26_1/BotNmsAdapter2610.java
+++ b/paper-versions/paper.26.1.x/src/main/java/com/pvpindex/paper/v1_26_1/BotNmsAdapter2610.java
@@ -1,0 +1,99 @@
+package com.pvpindex.paper.v1_26_1;
+
+import com.pvpindex.battles.practice.bot.BotNmsAdapter;
+import com.pvpindex.battles.practice.bot.NmsSpawnHelper;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * NMS bot adapter for <b>Paper 26.1.x</b> (Minecraft 1.21.4+).
+ *
+ * <p>Constructs a headless {@code net.minecraft.server.level.ServerPlayer} via
+ * reflection.  Paper 26.1.x introduces {@code ServerWaypointManager}: when a
+ * {@code ServerPlayer} is added to the level via {@code addFreshEntity} it is
+ * registered as a waypoint <em>receiver</em>.  If the spawn subsequently fails
+ * and the fake player retains a {@code null} connection, any future teleport of a
+ * real player triggers {@code WaypointTransmitter$EntityChunkConnection.disconnect}
+ * which calls {@code receiver.connection.send(packet)} and NPEs.</p>
+ *
+ * <p>The catch block therefore calls {@link NmsSpawnHelper#tryRemoveEntity}, which
+ * uses {@code ServerLevel.removePlayerImmediately(entity, RemovalReason.DISCARDED)}
+ * — the same cleanup path Paper itself uses for cross-world teleport — to fully
+ * unregister the entity from {@code ServerWaypointManager}, {@code EntityLookup},
+ * and {@code PlayerList} before re-throwing.</p>
+ */
+public final class BotNmsAdapter2610 implements BotNmsAdapter {
+
+    @Override
+    public LivingEntity spawnFakePlayer(World world, Location location, String name)
+            throws Exception {
+        Object nmsLevel = null;
+        Object bot = null;
+        try {
+            // 1 ── MinecraftServer ─────────────────────────────────────────────
+            Object craftServer = Bukkit.getServer();
+            Object nmsServer = craftServer.getClass()
+                    .getMethod("getServer")
+                    .invoke(craftServer);
+
+            // 2 ── ServerLevel ─────────────────────────────────────────────────
+            nmsLevel = world.getClass()
+                    .getMethod("getHandle")
+                    .invoke(world);
+
+            // 3 ── GameProfile ─────────────────────────────────────────────────
+            UUID botUuid = UUID.nameUUIDFromBytes(
+                    ("PracticeBot:" + name).getBytes(StandardCharsets.UTF_8));
+            Class<?> gpClass = Class.forName("com.mojang.authlib.GameProfile");
+            Object profile = gpClass
+                    .getConstructor(UUID.class, String.class)
+                    .newInstance(botUuid, name);
+
+            // 4 ── ClientInformation.createDefault() ───────────────────────────
+            Object clientInfo = NmsSpawnHelper.resolveClientInformationDefault();
+            if (clientInfo == null) {
+                throw new UnsupportedOperationException(
+                        "ClientInformation.createDefault() not found on 26.1.x");
+            }
+
+            // 5 ── ServerPlayer constructor ────────────────────────────────────
+            Class<?> spClass = Class.forName("net.minecraft.server.level.ServerPlayer");
+            Constructor<?> ctor = NmsSpawnHelper.resolveServerPlayerConstructor(spClass);
+            bot = ctor.newInstance(nmsServer, nmsLevel, profile, clientInfo);
+
+            // 6 ── Set initial position ────────────────────────────────────────
+            bot.getClass()
+                    .getMethod("setPos", double.class, double.class, double.class)
+                    .invoke(bot, location.getX(), location.getY(), location.getZ());
+
+            // 7 ── Add to world ────────────────────────────────────────────────
+            // addFreshEntity also registers the fake player in ServerWaypointManager
+            // as a receiver of nearby waypoints.  If this step succeeds and a later
+            // step throws, tryRemoveEntity MUST be called (see catch block).
+            NmsSpawnHelper.addFreshEntityReflective(nmsLevel, bot);
+
+            // 8 ── Wrap as Bukkit entity ───────────────────────────────────────
+            Object bukkit = bot.getClass().getMethod("getBukkitEntity").invoke(bot);
+            if (bukkit instanceof LivingEntity le) return le;
+            throw new IllegalStateException("getBukkitEntity() did not return a LivingEntity");
+
+        } catch (Exception e) {
+            // Critical on 26.1.x: removePlayerImmediately triggers the same
+            // ServerLevel.EntityCallbacks.onTrackingEnd path as a normal cross-world
+            // teleport, which calls ServerWaypointManager.removePlayer(fakeBotPlayer)
+            // → removeReceiver(fakeBotPlayer), cleanly removing the fake bot from the
+            // receiver map of every nearby waypoint (including the real player's).
+            // Without this, the next real-player teleportAsync will NPE inside
+            // WaypointTransmitter$EntityChunkConnection.disconnect().
+            if (bot != null) {
+                NmsSpawnHelper.tryRemoveEntity(nmsLevel, bot);
+            }
+            throw e;
+        }
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/command/BattleGuiCommand.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/command/BattleGuiCommand.java
@@ -3,6 +3,7 @@ package com.pvpindex.battles.command;
 import com.pvpindex.battles.battle.BattleService;
 import com.pvpindex.battles.battle.BattleSession;
 import com.pvpindex.battles.challenge.ChallengeManager;
+import com.pvpindex.battles.practice.PracticeManager;
 import com.pvpindex.battles.gamemode.GameModeDefinition;
 import com.pvpindex.battles.gamemode.GameModeRegistry;
 import com.pvpindex.battles.gui.GuiConfig;
@@ -52,6 +53,7 @@ public class BattleGuiCommand implements CommandExecutor {
 	private final MessageService messageService;
 	private ChallengeManager challengeManager;
 	private LeaderboardGui leaderboardGui;
+	private PracticeManager practiceManager;
 
 	private final Map<UUID, PlayerGuiState> guiStates = new ConcurrentHashMap<>();
 	private final NamespacedKey modeKey;
@@ -77,6 +79,12 @@ public class BattleGuiCommand implements CommandExecutor {
 	}
 
 	public LeaderboardGui leaderboardGui() { return leaderboardGui; }
+
+	public void setPracticeManager(PracticeManager practiceManager) {
+		this.practiceManager = practiceManager;
+	}
+
+	public PracticeManager practiceManager() { return practiceManager; }
 
 	public Map<UUID, PlayerGuiState> guiStates() { return guiStates; }
 	public NamespacedKey modeKey() { return modeKey; }
@@ -104,6 +112,7 @@ public class BattleGuiCommand implements CommandExecutor {
 			case "accept"       -> handleAccept(player, args);
 			case "decline"      -> handleDecline(player, args);
 			case "leaderboard", "lb", "top" -> handleLeaderboard(player, args);
+			case "practice"     -> handlePractice(player);
 			default             -> false;
 		};
 	}
@@ -177,6 +186,15 @@ public class BattleGuiCommand implements CommandExecutor {
 		}
 		String modeId = args.length >= 2 ? args[1] : null;
 		leaderboardGui.open(player, modeId);
+		return true;
+	}
+
+	private boolean handlePractice(Player player) {
+		if (practiceManager != null) {
+			practiceManager.openPracticeGui(player);
+		} else {
+			player.sendMessage("\u00A7cPractice mode is not enabled on this server.");
+		}
 		return true;
 	}
 
@@ -284,6 +302,12 @@ public class BattleGuiCommand implements CommandExecutor {
 		inv.setItem(guiConfig.queueTabSlot(), queueTab);
 		inv.setItem(guiConfig.challengeTabSlot(), challengeTab);
 		inv.setItem(guiConfig.activeBattlesSlot(), activeBattles);
+
+		// Practice tab at slot 39 (only shown when practice mode is enabled)
+		if (practiceManager != null) {
+			ItemStack practiceTab = buildTab(Material.BOOK, "\u00A7b\u00A7lPractice", false);
+			inv.setItem(39, practiceTab);
+		}
 	}
 
 	private static ItemStack buildTab(Material material, String name, boolean active) {

--- a/platform-paper/src/main/java/com/pvpindex/battles/gui/PlayerGuiState.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/gui/PlayerGuiState.java
@@ -8,7 +8,8 @@ public final class PlayerGuiState {
 
 	public enum Mode {
 		QUEUE,
-		CHALLENGE
+		CHALLENGE,
+		PRACTICE
 	}
 
 	private Mode mode;

--- a/platform-paper/src/main/java/com/pvpindex/battles/listener/PracticeListener.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/listener/PracticeListener.java
@@ -1,0 +1,221 @@
+package com.pvpindex.battles.listener;
+
+import com.pvpindex.battles.command.BattleGuiCommand;
+import com.pvpindex.battles.practice.PracticeManager;
+import com.pvpindex.battles.practice.PracticeMode;
+import com.pvpindex.battles.practice.reaction.ReactionTarget;
+import com.pvpindex.battles.practice.reaction.ReactionTrainer;
+import com.pvpindex.battles.practice.bot.BotSession;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Handles all events for the practice mode system:
+ *
+ * <ul>
+ *   <li><b>Reaction hits</b>: when a player sword-swings and lands on a
+ *       reaction-target {@link ArmorStand}, the hit is credited and the
+ *       target bursts.</li>
+ *   <li><b>Bot combat</b>: lets the real damage pipeline run; monitors the
+ *       bot's health and calls {@link PracticeManager#onBotDefeated} when it
+ *       reaches zero.</li>
+ *   <li><b>Practice GUI</b>: handles clicks inside the practice-mode selection
+ *       inventory (identified by {@link PracticeManager#GUI_TITLE}).</li>
+ *   <li><b>Session teardown</b>: ends sessions on player death / quit.</li>
+ * </ul>
+ */
+public final class PracticeListener implements Listener {
+
+    // HP threshold at which we proactively end the bot duel to avoid NMS death crash
+    private static final double BOT_DEATH_HP_THRESHOLD = 1.0;
+
+    private final PracticeManager practiceManager;
+    private final BattleGuiCommand battleGuiCommand;
+
+    public PracticeListener(PracticeManager practiceManager, BattleGuiCommand battleGuiCommand) {
+        this.practiceManager  = practiceManager;
+        this.battleGuiCommand = battleGuiCommand;
+    }
+
+    // ── Damage events ─────────────────────────────────────────────────────────
+
+    /**
+     * Handles two cases:
+     * <ol>
+     *   <li>Player hits a reaction-target ArmorStand → credit hit + burst.</li>
+     *   <li>Player hits the practice bot → let damage run normally, then check
+     *       if the bot should be considered defeated.</li>
+     * </ol>
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player attacker)) return;
+        Entity target = event.getEntity();
+
+        // ── Case 1: Reaction target hit ────────────────────────────────────
+        if (target instanceof ArmorStand stand) {
+            if (stand.getPersistentDataContainer().has(ReactionTarget.PDC_KEY, PersistentDataType.BYTE)) {
+                event.setCancelled(true); // don't break the armorstand; remove via ReactionTarget
+                ReactionTrainer trainer = practiceManager.getTrainer(attacker.getUniqueId());
+                if (trainer == null) return;
+                // Find the matching ReactionTarget
+                for (ReactionTarget rt : trainer.activeTargets()) {
+                    if (rt.stand().getEntityId() == stand.getEntityId() && !rt.isRemoved()) {
+                        trainer.onTargetHit(rt);
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+
+        // ── Case 2: Bot hit check ──────────────────────────────────────────
+        BotSession bs = practiceManager.getBotSession(attacker.getUniqueId());
+        if (bs == null || bs.isEnded()) return;
+        if (bs.opponent().entity().getEntityId() != target.getEntityId()) return;
+
+        // Let the normal damage run; after the event, check if HP is critical
+        // We schedule a 1-tick delayed check so the damage has been applied
+        try {
+            org.bukkit.plugin.Plugin plugin = getPlugin(attacker);
+            target.getServer().getScheduler().runTask(plugin, () -> {
+                if (bs.isEnded()) return;
+                double hp = bs.opponent().getHealth();
+                if (hp <= BOT_DEATH_HP_THRESHOLD) {
+                    practiceManager.onBotDefeated(attacker);
+                }
+            });
+        } catch (IllegalStateException ignored) {
+            // Plugin not found during shutdown — skip deferred check
+        }
+    }
+
+    /** Catch the bot's actual EntityDeathEvent in case HP hits 0 before our threshold check. */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onEntityDeath(EntityDeathEvent event) {
+        // Find which player owns a bot session with this entity
+        for (var entry : iterateBotSessions()) {
+            BotSession bs = entry.botSession();
+            if (bs.isEnded()) continue;
+            if (bs.opponent().entity().getEntityId() == event.getEntity().getEntityId()) {
+                event.setDroppedExp(0);
+                event.getDrops().clear();
+                Player owner = event.getEntity().getServer().getPlayer(entry.ownerUuid());
+                if (owner != null) {
+                    practiceManager.onBotDefeated(owner);
+                }
+                return;
+            }
+        }
+    }
+
+    // ── Player events ──────────────────────────────────────────────────────────
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getPlayer();
+        if (!practiceManager.isInPractice(player.getUniqueId())) return;
+        event.setDeathMessage(null);
+        event.getDrops().clear();
+        event.setDroppedExp(0);
+        event.setKeepInventory(true);
+        // End session; state will be restored
+        player.getServer().getScheduler().runTask(
+                getPlugin(player), () -> practiceManager.endSession(player));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        if (practiceManager.isInPractice(player.getUniqueId())) {
+            practiceManager.endSession(player);
+        }
+    }
+
+    // ── Practice GUI clicks ────────────────────────────────────────────────────
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        String title = event.getView().getTitle();
+
+        // Practice mode selection GUI
+        if (PracticeManager.GUI_TITLE.equals(title)) {
+            event.setCancelled(true);
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null || clicked.getType() == Material.AIR) return;
+
+            int slot = event.getRawSlot();
+            switch (slot) {
+                case 11 -> { // Reaction Training
+                    player.closeInventory();
+                    practiceManager.startSession(player, PracticeMode.REACTION_TRAINING, null);
+                }
+                case 13 -> { // Bot Duel
+                    player.closeInventory();
+                    practiceManager.startSession(player, PracticeMode.BOT_DUEL, null);
+                }
+                case 22 -> { // Back → open /battle GUI
+                    player.closeInventory();
+                    if (battleGuiCommand != null) {
+                        battleGuiCommand.onCommand(player,
+                                player.getServer().getPluginCommand("battle"),
+                                "battle", new String[0]);
+                    }
+                }
+                default -> { /* ignore filler clicks */ }
+            }
+            return;
+        }
+
+        // Practice tab click inside the battle GUI (slot 39)
+        if (battleGuiCommand != null && battleGuiCommand.guiConfig().battleTitle().equals(title)) {
+            if (event.getRawSlot() == 39) {
+                event.setCancelled(true);
+                player.closeInventory();
+                practiceManager.openPracticeGui(player);
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the owning plugin for a Bukkit player's server — used for
+     * scheduling delayed tasks.  Falls back gracefully if plugin lookup fails.
+     */
+    private org.bukkit.plugin.Plugin getPlugin(Player player) {
+        org.bukkit.plugin.Plugin p = player.getServer().getPluginManager().getPlugin("PvPIndexBattles");
+        if (p != null) return p;
+        throw new IllegalStateException("PvPIndexBattles plugin not found — cannot schedule task.");
+    }
+
+    /**
+     * Snapshot of (ownerUuid, botSession) pairs for safe iteration in
+     * EntityDeathEvent (avoids ConcurrentModificationException).
+     */
+    private Iterable<BotSessionEntry> iterateBotSessions() {
+        var result = new java.util.ArrayList<BotSessionEntry>();
+        for (Player online : org.bukkit.Bukkit.getOnlinePlayers()) {
+            BotSession bs = practiceManager.getBotSession(online.getUniqueId());
+            if (bs != null) result.add(new BotSessionEntry(online.getUniqueId(), bs));
+        }
+        return result;
+    }
+
+    private record BotSessionEntry(java.util.UUID ownerUuid, BotSession botSession) {}
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeCommand.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeCommand.java
@@ -1,0 +1,67 @@
+package com.pvpindex.battles.practice;
+
+import com.pvpindex.battles.util.MessageService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Handles the {@code /practice} command tree:
+ * <ul>
+ *   <li>{@code /practice}              — opens practice-mode selection GUI</li>
+ *   <li>{@code /practice reaction [gameMode]} — start reaction training</li>
+ *   <li>{@code /practice bot [gameMode]}      — start bot duel</li>
+ *   <li>{@code /practice stop}         — end current practice session</li>
+ * </ul>
+ *
+ * <p>Requires the {@code pvpindex.practice} permission (default: true).</p>
+ */
+public final class PracticeCommand implements CommandExecutor {
+
+    private final PracticeManager practiceManager;
+    private final MessageService messageService;
+
+    public PracticeCommand(PracticeManager practiceManager, MessageService messageService) {
+        this.practiceManager = practiceManager;
+        this.messageService  = messageService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        if (!player.hasPermission("pvpindex.practice")) {
+            messageService.send(player, "general.no_permission");
+            return true;
+        }
+
+        if (args.length == 0) {
+            practiceManager.openPracticeGui(player);
+            return true;
+        }
+
+        return switch (args[0].toLowerCase()) {
+            case "reaction" -> {
+                String gameModeId = args.length >= 2 ? args[1] : null;
+                practiceManager.startSession(player, PracticeMode.REACTION_TRAINING, gameModeId);
+                yield true;
+            }
+            case "bot" -> {
+                String gameModeId = args.length >= 2 ? args[1] : null;
+                practiceManager.startSession(player, PracticeMode.BOT_DUEL, gameModeId);
+                yield true;
+            }
+            case "stop" -> {
+                practiceManager.endSession(player);
+                yield true;
+            }
+            default -> {
+                player.sendMessage("\u00A7cUsage: /practice [reaction|bot|stop] [gameMode]");
+                yield true;
+            }
+        };
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
@@ -12,6 +12,7 @@ import com.pvpindex.battles.world.ArenaPoolService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -103,8 +104,11 @@ public final class PracticeManager {
         }
         Bukkit.getScheduler().runTask(plugin, () -> {
             if (!player.isOnline()) return;
-            ArenaInstance arena = acquireAndTeleport(player);
-            launchMode(player, session, mode, gameModeId, arena);
+            acquireAndTeleport(player).thenAccept(arena -> {
+                if (!player.isOnline()) return;
+                Bukkit.getScheduler().runTask(plugin,
+                        () -> launchMode(player, session, mode, gameModeId, arena));
+            });
         });
     }
 
@@ -281,12 +285,14 @@ public final class PracticeManager {
      *
      * @return the acquired instance, or {@code null} if none was available
      */
-    private ArenaInstance acquireAndTeleport(Player player) {
+    private CompletableFuture<ArenaInstance> acquireAndTeleport(Player player) {
         String templateId = settings.practiceTemplateId();
-        if (templateId == null || templateId.isBlank() || arenaPool == null) return null;
+        if (templateId == null || templateId.isBlank() || arenaPool == null) {
+            return CompletableFuture.completedFuture(null);
+        }
         try {
             ArenaInstance arena = arenaPool.acquire(templateId).orElse(null);
-            if (arena == null) return null;
+            if (arena == null) return CompletableFuture.completedFuture(null);
             practiceArenas.put(player.getUniqueId(), arena);
             List<SpawnPoint> spawns = arena.spawnPoints();
             if (spawns != null && !spawns.isEmpty()) {
@@ -295,13 +301,17 @@ public final class PracticeManager {
                 if (world != null) {
                     // teleportAsync uses Paper's async chunk system to pre-load
                     // destination chunks before completing the cross-world move.
-                    player.teleportAsync(new Location(world, s0.x(), s0.y(), s0.z(), s0.yaw(), s0.pitch()));
+                    // Chain the arena result onto the future so callers wait for
+                    // the teleport to finish before spawning the bot.
+                    return player.teleportAsync(
+                            new Location(world, s0.x(), s0.y(), s0.z(), s0.yaw(), s0.pitch()))
+                            .thenApply(success -> arena);
                 }
             }
-            return arena;
+            return CompletableFuture.completedFuture(arena);
         } catch (Exception e) {
             plugin.getLogger().warning("[Practice] Could not acquire arena '" + templateId + "': " + e.getMessage());
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
     }
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
@@ -1,11 +1,15 @@
 package com.pvpindex.battles.practice;
 
+import com.pvpindex.battles.arena.SpawnPoint;
 import com.pvpindex.battles.battle.PlayerStateService;
 import com.pvpindex.battles.gamemode.GameModeRegistry;
 import com.pvpindex.battles.gamemode.KitApplier;
 import com.pvpindex.battles.gamemode.KitDefinition;
 import com.pvpindex.battles.practice.bot.BotSession;
 import com.pvpindex.battles.practice.reaction.ReactionTrainer;
+import com.pvpindex.battles.world.ArenaInstance;
+import com.pvpindex.battles.world.ArenaPoolService;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,6 +18,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -37,21 +42,25 @@ public final class PracticeManager {
     private final KitApplier kitApplier;
     private final GameModeRegistry gameModeRegistry;
     private final PracticeSettings settings;
+    private final ArenaPoolService arenaPool;
 
-    private final Map<UUID, PracticeSession> sessions  = new ConcurrentHashMap<>();
-    private final Map<UUID, ReactionTrainer> trainers  = new ConcurrentHashMap<>();
+    private final Map<UUID, PracticeSession> sessions    = new ConcurrentHashMap<>();
+    private final Map<UUID, ReactionTrainer> trainers    = new ConcurrentHashMap<>();
     private final Map<UUID, BotSession>       botSessions = new ConcurrentHashMap<>();
+    private final Map<UUID, ArenaInstance>   practiceArenas = new ConcurrentHashMap<>();
 
     public PracticeManager(Plugin plugin,
             PlayerStateService playerStateService,
             KitApplier kitApplier,
             GameModeRegistry gameModeRegistry,
-            PracticeSettings settings) {
+            PracticeSettings settings,
+            ArenaPoolService arenaPool) {
         this.plugin = plugin;
         this.playerStateService = playerStateService;
         this.kitApplier = kitApplier;
         this.gameModeRegistry = gameModeRegistry;
         this.settings = settings;
+        this.arenaPool = arenaPool;
     }
 
     // ── Session lifecycle ─────────────────────────────────────────────────────
@@ -81,9 +90,26 @@ public final class PracticeManager {
                 gameModeId != null ? gameModeId : settings.botKitId());
         sessions.put(player.getUniqueId(), session);
 
+        // Acquire a practice arena and teleport the player there
+        ArenaInstance arena = acquireAndTeleport(player);
+
         switch (mode) {
             case REACTION_TRAINING -> startReactionTraining(player, session);
-            case BOT_DUEL          -> startBotDuel(player, session);
+            case BOT_DUEL          -> {
+                // Determine bot spawn: arena spawn[1] when available, else 4 blocks ahead
+                Location botLoc = null;
+                if (arena != null) {
+                    List<SpawnPoint> spawns = arena.spawnPoints();
+                    if (spawns != null && spawns.size() >= 2) {
+                        SpawnPoint s1 = spawns.get(1);
+                        World world = Bukkit.getWorld(arena.worldName());
+                        if (world != null) {
+                            botLoc = new Location(world, s1.x(), s1.y(), s1.z(), s1.yaw(), s1.pitch());
+                        }
+                    }
+                }
+                startBotDuel(player, session, botLoc);
+            }
         }
     }
 
@@ -103,6 +129,8 @@ public final class PracticeManager {
             }
         }
 
+        releaseArena(player.getUniqueId());
+
         if (player.isOnline()) {
             playerStateService.restore(player);
             player.sendMessage(Component.text("Practice session ended.", NamedTextColor.YELLOW));
@@ -117,6 +145,7 @@ public final class PracticeManager {
         BotSession bs = botSessions.remove(player.getUniqueId());
         sessions.remove(player.getUniqueId());
         if (bs != null) bs.end(true); // shows "Bot Defeated!" title
+        releaseArena(player.getUniqueId());
         if (player.isOnline()) {
             playerStateService.restore(player);
         }
@@ -174,7 +203,7 @@ public final class PracticeManager {
         trainer.start(player, session);
     }
 
-    private void startBotDuel(Player player, PracticeSession session) {
+    private void startBotDuel(Player player, PracticeSession session, Location botSpawn) {
         String kitId = session.gameModeId() != null ? session.gameModeId() : settings.botKitId();
         KitDefinition kit = gameModeRegistry.findKit(kitId)
                 .orElseGet(() -> {
@@ -185,6 +214,7 @@ public final class PracticeManager {
         if (kit == null) {
             player.sendMessage(Component.text("No kit found for practice. Configure gamemodes.yml.", NamedTextColor.RED));
             sessions.remove(player.getUniqueId());
+            releaseArena(player.getUniqueId());
             playerStateService.restore(player);
             return;
         }
@@ -192,15 +222,56 @@ public final class PracticeManager {
         // Apply kit to the player too
         kitApplier.apply(player, kit);
 
-        // Spawn bot 4 blocks in front of the player
-        Location botLoc = player.getLocation().clone().add(
-                player.getLocation().getDirection().setY(0).normalize().multiply(4));
-        botLoc.setYaw(player.getLocation().getYaw() + 180f);
+        // Bot spawn: use arena spawn[1] if available, otherwise 4 blocks ahead
+        Location loc;
+        if (botSpawn != null) {
+            loc = botSpawn;
+        } else {
+            loc = player.getLocation().clone().add(
+                    player.getLocation().getDirection().setY(0).normalize().multiply(4));
+            loc.setYaw(player.getLocation().getYaw() + 180f);
+        }
 
         player.sendMessage(Component.text("Bot duel started! Defeat the practice bot.", NamedTextColor.GREEN));
 
-        BotSession bs = BotSession.spawn(plugin, player, botLoc, kit, kitApplier, settings);
+        BotSession bs = BotSession.spawn(plugin, player, loc, kit, kitApplier, settings);
         botSessions.put(player.getUniqueId(), bs);
+    }
+
+    /**
+     * Acquire a practice arena from the pool and teleport {@code player} to
+     * spawn[0].  Stores the {@link ArenaInstance} in {@code practiceArenas}.
+     *
+     * @return the acquired instance, or {@code null} if none was available
+     */
+    private ArenaInstance acquireAndTeleport(Player player) {
+        String templateId = settings.practiceTemplateId();
+        if (templateId == null || templateId.isBlank() || arenaPool == null) return null;
+        try {
+            ArenaInstance arena = arenaPool.acquire(templateId).orElse(null);
+            if (arena == null) return null;
+            practiceArenas.put(player.getUniqueId(), arena);
+            List<SpawnPoint> spawns = arena.spawnPoints();
+            if (spawns != null && !spawns.isEmpty()) {
+                SpawnPoint s0 = spawns.get(0);
+                World world = Bukkit.getWorld(arena.worldName());
+                if (world != null) {
+                    player.teleport(new Location(world, s0.x(), s0.y(), s0.z(), s0.yaw(), s0.pitch()));
+                }
+            }
+            return arena;
+        } catch (Exception e) {
+            plugin.getLogger().warning("[Practice] Could not acquire arena '" + templateId + "': " + e.getMessage());
+            return null;
+        }
+    }
+
+    /** Release the arena held by {@code uuid} back to the pool. */
+    private void releaseArena(UUID uuid) {
+        ArenaInstance arena = practiceArenas.remove(uuid);
+        if (arena != null && arenaPool != null) {
+            arenaPool.release(arena);
+        }
     }
 
     private static ItemStack buildGuiItem(Material material, String name, String... loreParts) {

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
@@ -1,0 +1,216 @@
+package com.pvpindex.battles.practice;
+
+import com.pvpindex.battles.battle.PlayerStateService;
+import com.pvpindex.battles.gamemode.GameModeRegistry;
+import com.pvpindex.battles.gamemode.KitApplier;
+import com.pvpindex.battles.gamemode.KitDefinition;
+import com.pvpindex.battles.practice.bot.BotSession;
+import com.pvpindex.battles.practice.reaction.ReactionTrainer;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Central service for the practice system.
+ *
+ * <p>Manages the per-player {@link PracticeSession} lifecycle, delegates to
+ * {@link ReactionTrainer} and {@link BotSession} for the two sub-modes, and
+ * owns the practice-mode selection GUI.</p>
+ */
+public final class PracticeManager {
+
+    /** Inventory title used both to build and to identify the practice GUI. */
+    public static final String GUI_TITLE = "\u00A76\u00A7lPractice Mode";
+
+    private final Plugin plugin;
+    private final PlayerStateService playerStateService;
+    private final KitApplier kitApplier;
+    private final GameModeRegistry gameModeRegistry;
+    private final PracticeSettings settings;
+
+    private final Map<UUID, PracticeSession> sessions  = new ConcurrentHashMap<>();
+    private final Map<UUID, ReactionTrainer> trainers  = new ConcurrentHashMap<>();
+    private final Map<UUID, BotSession>       botSessions = new ConcurrentHashMap<>();
+
+    public PracticeManager(Plugin plugin,
+            PlayerStateService playerStateService,
+            KitApplier kitApplier,
+            GameModeRegistry gameModeRegistry,
+            PracticeSettings settings) {
+        this.plugin = plugin;
+        this.playerStateService = playerStateService;
+        this.kitApplier = kitApplier;
+        this.gameModeRegistry = gameModeRegistry;
+        this.settings = settings;
+    }
+
+    // ── Session lifecycle ─────────────────────────────────────────────────────
+
+    /**
+     * Enter practice mode for {@code player}.
+     *
+     * @param player     the player
+     * @param mode       which sub-mode to start
+     * @param gameModeId optional game-mode kit override; {@code null} uses
+     *                   {@link PracticeSettings#botKitId()}
+     */
+    public void startSession(Player player, PracticeMode mode, String gameModeId) {
+        if (!settings.enabled()) {
+            player.sendMessage(Component.text("Practice mode is not enabled on this server.", NamedTextColor.RED));
+            return;
+        }
+        if (isInPractice(player.getUniqueId())) {
+            player.sendMessage(Component.text("You are already in a practice session. Use /practice stop to exit.",
+                    NamedTextColor.YELLOW));
+            return;
+        }
+
+        playerStateService.save(player);
+
+        PracticeSession session = new PracticeSession(player.getUniqueId(), mode,
+                gameModeId != null ? gameModeId : settings.botKitId());
+        sessions.put(player.getUniqueId(), session);
+
+        switch (mode) {
+            case REACTION_TRAINING -> startReactionTraining(player, session);
+            case BOT_DUEL          -> startBotDuel(player, session);
+        }
+    }
+
+    /** End and clean up the practice session for {@code player}. */
+    public void endSession(Player player) {
+        PracticeSession session = sessions.remove(player.getUniqueId());
+        if (session == null) return;
+
+        switch (session.mode()) {
+            case REACTION_TRAINING -> {
+                ReactionTrainer trainer = trainers.remove(player.getUniqueId());
+                if (trainer != null) trainer.stop();
+            }
+            case BOT_DUEL -> {
+                BotSession bs = botSessions.remove(player.getUniqueId());
+                if (bs != null) bs.end(false);
+            }
+        }
+
+        if (player.isOnline()) {
+            playerStateService.restore(player);
+            player.sendMessage(Component.text("Practice session ended.", NamedTextColor.YELLOW));
+        }
+    }
+
+    /**
+     * Called from {@link com.pvpindex.battles.listener.PracticeListener} when
+     * the bot is defeated.  Ends the session, credits the player.
+     */
+    public void onBotDefeated(Player player) {
+        BotSession bs = botSessions.remove(player.getUniqueId());
+        sessions.remove(player.getUniqueId());
+        if (bs != null) bs.end(true); // shows "Bot Defeated!" title
+        if (player.isOnline()) {
+            playerStateService.restore(player);
+        }
+    }
+
+    // ── Practice GUI ──────────────────────────────────────────────────────────
+
+    /**
+     * Open the practice-mode selection inventory for {@code player}.
+     * Clicks are handled by
+     * {@link com.pvpindex.battles.listener.PracticeListener}.
+     */
+    public void openPracticeGui(Player player) {
+        if (!settings.enabled()) {
+            player.sendMessage(Component.text("Practice mode is not enabled on this server.", NamedTextColor.RED));
+            return;
+        }
+        Inventory inv = Bukkit.createInventory(null, 27, GUI_TITLE);
+
+        // Slot 11 — Reaction Training
+        inv.setItem(11, buildGuiItem(Material.CLOCK,
+                "\u00A7b\u00A7lReaction Training",
+                "\u00A77Hit the glowing targets as fast as you can!",
+                "\u00A7aClick to start"));
+
+        // Slot 13 — Bot Duel
+        inv.setItem(13, buildGuiItem(Material.SKELETON_SKULL,
+                "\u00A76\u00A7lBot Duel",
+                "\u00A77Fight a mid-level practice bot.",
+                "\u00A7aClick to start"));
+
+        // Slot 22 — Back
+        inv.setItem(22, buildGuiItem(Material.ARROW,
+                "\u00A77\u2190 Back",
+                "\u00A77Return to the Battle menu."));
+
+        player.openInventory(inv);
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    public boolean isInPractice(UUID playerUuid)       { return sessions.containsKey(playerUuid); }
+    public PracticeSession getSession(UUID playerUuid) { return sessions.get(playerUuid); }
+    public ReactionTrainer getTrainer(UUID playerUuid) { return trainers.get(playerUuid); }
+    public BotSession getBotSession(UUID playerUuid)   { return botSessions.get(playerUuid); }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private void startReactionTraining(Player player, PracticeSession session) {
+        player.sendMessage(Component.text(
+                "Reaction training started! Hit the glowing targets as fast as you can.",
+                NamedTextColor.GREEN));
+        ReactionTrainer trainer = new ReactionTrainer(plugin, settings);
+        trainers.put(player.getUniqueId(), trainer);
+        trainer.start(player, session);
+    }
+
+    private void startBotDuel(Player player, PracticeSession session) {
+        String kitId = session.gameModeId() != null ? session.gameModeId() : settings.botKitId();
+        KitDefinition kit = gameModeRegistry.findKit(kitId)
+                .orElseGet(() -> {
+                    // fallback: look for any kit
+                    var kits = gameModeRegistry.allKits();
+                    return kits.isEmpty() ? null : kits.iterator().next();
+                });
+        if (kit == null) {
+            player.sendMessage(Component.text("No kit found for practice. Configure gamemodes.yml.", NamedTextColor.RED));
+            sessions.remove(player.getUniqueId());
+            playerStateService.restore(player);
+            return;
+        }
+
+        // Apply kit to the player too
+        kitApplier.apply(player, kit);
+
+        // Spawn bot 4 blocks in front of the player
+        Location botLoc = player.getLocation().clone().add(
+                player.getLocation().getDirection().setY(0).normalize().multiply(4));
+        botLoc.setYaw(player.getLocation().getYaw() + 180f);
+
+        player.sendMessage(Component.text("Bot duel started! Defeat the practice bot.", NamedTextColor.GREEN));
+
+        BotSession bs = BotSession.spawn(plugin, player, botLoc, kit, kitApplier, settings);
+        botSessions.put(player.getUniqueId(), bs);
+    }
+
+    private static ItemStack buildGuiItem(Material material, String name, String... loreParts) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(java.util.Arrays.asList(loreParts));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
@@ -90,9 +90,27 @@ public final class PracticeManager {
                 gameModeId != null ? gameModeId : settings.botKitId());
         sessions.put(player.getUniqueId(), session);
 
-        // Acquire a practice arena and teleport the player there
-        ArenaInstance arena = acquireAndTeleport(player);
+        // When the arena pool is cold, world generation can take ~300 ms on the
+        // main thread. Schedule the heavy acquire + teleport to the very next
+        // tick so this command handler returns immediately. For a warm pool the
+        // 1-tick deferral is imperceptible.
+        String templateId = settings.practiceTemplateId();
+        boolean poolCold = arenaPool != null
+                && templateId != null && !templateId.isBlank()
+                && arenaPool.poolSize(templateId) == 0;
+        if (poolCold) {
+            player.sendMessage(Component.text("Generating practice arena, one moment...", NamedTextColor.YELLOW));
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (!player.isOnline()) return;
+            ArenaInstance arena = acquireAndTeleport(player);
+            launchMode(player, session, mode, gameModeId, arena);
+        });
+    }
 
+    /** Start the appropriate sub-mode after the arena has been acquired and the player teleported. */
+    private void launchMode(Player player, PracticeSession session, PracticeMode mode,
+            String gameModeId, ArenaInstance arena) {
         switch (mode) {
             case REACTION_TRAINING -> startReactionTraining(player, session);
             case BOT_DUEL          -> {
@@ -275,7 +293,9 @@ public final class PracticeManager {
                 SpawnPoint s0 = spawns.get(0);
                 World world = Bukkit.getWorld(arena.worldName());
                 if (world != null) {
-                    player.teleport(new Location(world, s0.x(), s0.y(), s0.z(), s0.yaw(), s0.pitch()));
+                    // teleportAsync uses Paper's async chunk system to pre-load
+                    // destination chunks before completing the cross-world move.
+                    player.teleportAsync(new Location(world, s0.x(), s0.y(), s0.z(), s0.yaw(), s0.pitch()));
                 }
             }
             return arena;

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeManager.java
@@ -199,6 +199,25 @@ public final class PracticeManager {
                 "Reaction training started! Hit the glowing targets as fast as you can.",
                 NamedTextColor.GREEN));
         ReactionTrainer trainer = new ReactionTrainer(plugin, settings);
+
+        // Pass the arena floor centre so targets spawn within arena bounds
+        ArenaInstance arena = practiceArenas.get(player.getUniqueId());
+        if (arena != null) {
+            World world = Bukkit.getWorld(arena.worldName());
+            List<SpawnPoint> spawns = arena.spawnPoints();
+            if (world != null && spawns != null && !spawns.isEmpty()) {
+                SpawnPoint s0 = spawns.get(0);
+                if (spawns.size() >= 2) {
+                    SpawnPoint s1 = spawns.get(1);
+                    trainer.setArenaCenter(new Location(world,
+                            (s0.x() + s1.x()) / 2.0, s0.y(),
+                            (s0.z() + s1.z()) / 2.0));
+                } else {
+                    trainer.setArenaCenter(new Location(world, s0.x(), s0.y(), s0.z()));
+                }
+            }
+        }
+
         trainers.put(player.getUniqueId(), trainer);
         trainer.start(player, session);
     }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
@@ -1,0 +1,73 @@
+package com.pvpindex.battles.practice;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+
+/**
+ * All configurable values for the practice system, loaded from {@code practice.yml}.
+ */
+public final class PracticeSettings {
+
+    private final boolean enabled;
+
+    // ── Reaction training ────────────────────────────────────────────────
+    private final int reactionMaxTargets;
+    private final int reactionSpawnIntervalTicks;
+    private final int reactionTargetLifetimeTicks;
+
+    // ── Bot duel ─────────────────────────────────────────────────────────
+    private final String botKitId;
+    private final int botAttackIntervalTicks;
+    private final double botMoveSpeed;
+    private final double botAttackDamage;
+    private final boolean botUseNms;
+
+    public PracticeSettings(boolean enabled,
+            int reactionMaxTargets,
+            int reactionSpawnIntervalTicks,
+            int reactionTargetLifetimeTicks,
+            String botKitId,
+            int botAttackIntervalTicks,
+            double botMoveSpeed,
+            double botAttackDamage,
+            boolean botUseNms) {
+        this.enabled = enabled;
+        this.reactionMaxTargets = reactionMaxTargets;
+        this.reactionSpawnIntervalTicks = reactionSpawnIntervalTicks;
+        this.reactionTargetLifetimeTicks = reactionTargetLifetimeTicks;
+        this.botKitId = botKitId;
+        this.botAttackIntervalTicks = botAttackIntervalTicks;
+        this.botMoveSpeed = botMoveSpeed;
+        this.botAttackDamage = botAttackDamage;
+        this.botUseNms = botUseNms;
+    }
+
+    /** Load from a {@code practice.yml} YamlConfiguration. */
+    public static PracticeSettings from(YamlConfiguration yaml) {
+        return new PracticeSettings(
+                yaml.getBoolean("practice.enabled", true),
+                yaml.getInt("practice.reaction_training.max_targets", 5),
+                yaml.getInt("practice.reaction_training.spawn_interval_ticks", 40),
+                yaml.getInt("practice.reaction_training.target_lifetime_ticks", 100),
+                yaml.getString("practice.bot.kit_id", "sword_starter"),
+                yaml.getInt("practice.bot.attack_interval_ticks", 10),
+                yaml.getDouble("practice.bot.move_speed", 0.28),
+                yaml.getDouble("practice.bot.attack_damage", 3.0),
+                yaml.getBoolean("practice.bot.use_nms_fake_player", true)
+        );
+    }
+
+    /** @return sensible hard-coded defaults for unit tests / fresh installs. */
+    public static PracticeSettings defaults() {
+        return new PracticeSettings(true, 5, 40, 100, "sword_starter", 10, 0.28, 3.0, true);
+    }
+
+    public boolean enabled()                   { return enabled; }
+    public int reactionMaxTargets()            { return reactionMaxTargets; }
+    public int reactionSpawnIntervalTicks()    { return reactionSpawnIntervalTicks; }
+    public int reactionTargetLifetimeTicks()   { return reactionTargetLifetimeTicks; }
+    public String botKitId()                   { return botKitId; }
+    public int botAttackIntervalTicks()        { return botAttackIntervalTicks; }
+    public double botMoveSpeed()               { return botMoveSpeed; }
+    public double botAttackDamage()            { return botAttackDamage; }
+    public boolean botUseNms()                 { return botUseNms; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 public final class PracticeSettings {
 
     private final boolean enabled;
+    private final String practiceTemplateId;
 
     // ── Reaction training ────────────────────────────────────────────────
     private final int reactionMaxTargets;
@@ -22,6 +23,7 @@ public final class PracticeSettings {
     private final boolean botUseNms;
 
     public PracticeSettings(boolean enabled,
+            String practiceTemplateId,
             int reactionMaxTargets,
             int reactionSpawnIntervalTicks,
             int reactionTargetLifetimeTicks,
@@ -31,6 +33,7 @@ public final class PracticeSettings {
             double botAttackDamage,
             boolean botUseNms) {
         this.enabled = enabled;
+        this.practiceTemplateId = practiceTemplateId;
         this.reactionMaxTargets = reactionMaxTargets;
         this.reactionSpawnIntervalTicks = reactionSpawnIntervalTicks;
         this.reactionTargetLifetimeTicks = reactionTargetLifetimeTicks;
@@ -45,6 +48,7 @@ public final class PracticeSettings {
     public static PracticeSettings from(YamlConfiguration yaml) {
         return new PracticeSettings(
                 yaml.getBoolean("practice.enabled", true),
+                yaml.getString("practice.template_id", "arena_duel"),
                 yaml.getInt("practice.reaction_training.max_targets", 5),
                 yaml.getInt("practice.reaction_training.spawn_interval_ticks", 40),
                 yaml.getInt("practice.reaction_training.target_lifetime_ticks", 100),
@@ -58,10 +62,11 @@ public final class PracticeSettings {
 
     /** @return sensible hard-coded defaults for unit tests / fresh installs. */
     public static PracticeSettings defaults() {
-        return new PracticeSettings(true, 5, 40, 100, "sword_starter", 10, 0.28, 3.0, true);
+        return new PracticeSettings(true, "arena_duel", 5, 40, 100, "sword_starter", 10, 0.28, 3.0, true);
     }
 
     public boolean enabled()                   { return enabled; }
+    public String practiceTemplateId()         { return practiceTemplateId; }
     public int reactionMaxTargets()            { return reactionMaxTargets; }
     public int reactionSpawnIntervalTicks()    { return reactionSpawnIntervalTicks; }
     public int reactionTargetLifetimeTicks()   { return reactionTargetLifetimeTicks; }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeSettings.java
@@ -13,8 +13,9 @@ public final class PracticeSettings {
     // ── Reaction training ────────────────────────────────────────────────
     private final int reactionMaxTargets;
     private final int reactionSpawnIntervalTicks;
-    private final int reactionTargetLifetimeTicks;
-
+    private final int reactionTargetLifetimeTicks;    private final String reactionSpawnMode;
+    private final double reactionArenaSpawnRadius;
+    private final double reactionArenaHeightRange;
     // ── Bot duel ─────────────────────────────────────────────────────────
     private final String botKitId;
     private final int botAttackIntervalTicks;
@@ -27,6 +28,9 @@ public final class PracticeSettings {
             int reactionMaxTargets,
             int reactionSpawnIntervalTicks,
             int reactionTargetLifetimeTicks,
+            String reactionSpawnMode,
+            double reactionArenaSpawnRadius,
+            double reactionArenaHeightRange,
             String botKitId,
             int botAttackIntervalTicks,
             double botMoveSpeed,
@@ -37,6 +41,9 @@ public final class PracticeSettings {
         this.reactionMaxTargets = reactionMaxTargets;
         this.reactionSpawnIntervalTicks = reactionSpawnIntervalTicks;
         this.reactionTargetLifetimeTicks = reactionTargetLifetimeTicks;
+        this.reactionSpawnMode = reactionSpawnMode;
+        this.reactionArenaSpawnRadius = reactionArenaSpawnRadius;
+        this.reactionArenaHeightRange = reactionArenaHeightRange;
         this.botKitId = botKitId;
         this.botAttackIntervalTicks = botAttackIntervalTicks;
         this.botMoveSpeed = botMoveSpeed;
@@ -52,17 +59,20 @@ public final class PracticeSettings {
                 yaml.getInt("practice.reaction_training.max_targets", 5),
                 yaml.getInt("practice.reaction_training.spawn_interval_ticks", 40),
                 yaml.getInt("practice.reaction_training.target_lifetime_ticks", 100),
+                yaml.getString("practice.reaction_training.spawn_mode", "arena"),
+                yaml.getDouble("practice.reaction_training.arena_spawn_radius", 6.0),
+                yaml.getDouble("practice.reaction_training.arena_spawn_height_range", 1.5),
                 yaml.getString("practice.bot.kit_id", "sword_starter"),
                 yaml.getInt("practice.bot.attack_interval_ticks", 10),
                 yaml.getDouble("practice.bot.move_speed", 0.28),
                 yaml.getDouble("practice.bot.attack_damage", 3.0),
-                yaml.getBoolean("practice.bot.use_nms_fake_player", true)
+                yaml.getBoolean("practice.bot.use_nms_fake_player", false)
         );
     }
 
     /** @return sensible hard-coded defaults for unit tests / fresh installs. */
     public static PracticeSettings defaults() {
-        return new PracticeSettings(true, "arena_duel", 5, 40, 100, "sword_starter", 10, 0.28, 3.0, true);
+        return new PracticeSettings(true, "arena_duel", 5, 40, 100, "arena", 6.0, 1.5, "sword_starter", 10, 0.28, 3.0, false);
     }
 
     public boolean enabled()                   { return enabled; }
@@ -70,6 +80,9 @@ public final class PracticeSettings {
     public int reactionMaxTargets()            { return reactionMaxTargets; }
     public int reactionSpawnIntervalTicks()    { return reactionSpawnIntervalTicks; }
     public int reactionTargetLifetimeTicks()   { return reactionTargetLifetimeTicks; }
+    public String reactionSpawnMode()          { return reactionSpawnMode; }
+    public double reactionArenaSpawnRadius()   { return reactionArenaSpawnRadius; }
+    public double reactionArenaHeightRange()   { return reactionArenaHeightRange; }
     public String botKitId()                   { return botKitId; }
     public int botAttackIntervalTicks()        { return botAttackIntervalTicks; }
     public double botMoveSpeed()               { return botMoveSpeed; }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeTabCompleter.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/PracticeTabCompleter.java
@@ -1,0 +1,45 @@
+package com.pvpindex.battles.practice;
+
+import com.pvpindex.battles.gamemode.GameModeRegistry;
+import java.util.List;
+import java.util.Locale;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+/**
+ * Tab-completer for the {@code /practice} command.
+ */
+public final class PracticeTabCompleter implements TabCompleter {
+
+    private static final List<String> SUB_COMMANDS = List.of("reaction", "bot", "stop");
+
+    private final GameModeRegistry gameModeRegistry;
+
+    public PracticeTabCompleter(GameModeRegistry gameModeRegistry) {
+        this.gameModeRegistry = gameModeRegistry;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!(sender instanceof Player)) return List.of();
+
+        if (args.length == 1) {
+            String prefix = args[0].toLowerCase(Locale.ROOT);
+            return SUB_COMMANDS.stream()
+                    .filter(s -> s.startsWith(prefix))
+                    .toList();
+        }
+
+        if (args.length == 2 && (args[0].equalsIgnoreCase("reaction") || args[0].equalsIgnoreCase("bot"))) {
+            String prefix = args[1].toLowerCase(Locale.ROOT);
+            return gameModeRegistry.allModes().stream()
+                    .map(m -> m.id().toLowerCase(Locale.ROOT))
+                    .filter(id -> id.startsWith(prefix))
+                    .toList();
+        }
+
+        return List.of();
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotBehaviorTask.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotBehaviorTask.java
@@ -91,6 +91,13 @@ public final class BotBehaviorTask {
 
         Location botLoc    = bot.location();
         Location targetLoc = target.getLocation();
+
+        // Guard against world mismatch (e.g. player teleported to a different world).
+        if (botLoc.getWorld() == null || !botLoc.getWorld().equals(targetLoc.getWorld())) {
+            stop();
+            return;
+        }
+
         double dist = botLoc.distance(targetLoc);
 
         // ── Attack ────────────────────────────────────────────────────────

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotBehaviorTask.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotBehaviorTask.java
@@ -1,0 +1,171 @@
+package com.pvpindex.battles.practice.bot;
+
+import com.pvpindex.battles.practice.PracticeSettings;
+import java.util.UUID;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Drives the bot's movement and attack AI.
+ *
+ * <p>The task runs every 2 ticks (100 ms) on the Bukkit scheduler. On each
+ * tick it:</p>
+ * <ol>
+ *   <li>Computes the direction vector from the bot to the target player.</li>
+ *   <li>Applies a perpendicular strafe offset that flips every 60 ticks,
+ *       giving the bot a realistic side-to-side movement pattern.</li>
+ *   <li>Steps the bot toward the computed destination at
+ *       {@link PracticeSettings#botMoveSpeed()} blocks/tick.</li>
+ *   <li>Every {@link PracticeSettings#botAttackIntervalTicks()} ticks, deals
+ *       damage to the target player and plays melee-hit effects.</li>
+ * </ol>
+ *
+ * <p>If the bot HP drops below 20 % it enters a brief retreat phase
+ * (20 ticks) to simulate mid-level defensive play.</p>
+ */
+public final class BotBehaviorTask {
+
+    private static final double IDEAL_DISTANCE   = 2.0;  // blocks — sweet spot for melee
+    private static final double STOP_DISTANCE    = 1.3;  // closer than this: don't advance
+    private static final double RETREAT_DISTANCE = 4.5;  // retreat target distance
+    private static final double RETREAT_HP_FRAC  = 0.20; // retreat below 20 % HP
+    private static final int    STRAFE_FLIP_TICKS = 60;  // ticks before strafe direction flips
+
+    private final Plugin plugin;
+    private final BotOpponent bot;
+    private final PracticeSettings settings;
+
+    /** Target player UUID – looked up from Bukkit on each tick. */
+    private final UUID targetUuid;
+
+    private BukkitTask task;
+    private int tickCount      = 0;
+    private int strafeDirection = 1;  // +1 or -1
+    private int retreatTicks    = 0;
+    private boolean running     = false;
+
+    public BotBehaviorTask(Plugin plugin, BotOpponent bot, Player target, PracticeSettings settings) {
+        this.plugin = plugin;
+        this.bot = bot;
+        this.settings = settings;
+        this.targetUuid = target.getUniqueId();
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    /** Start the AI task. Safe to call only once per instance. */
+    public void start() {
+        if (running) return;
+        running = true;
+        task = plugin.getServer().getScheduler().runTaskTimer(plugin, this::tick, 2L, 2L);
+    }
+
+    /** Cancel the task. The bot entity is NOT removed here. */
+    public void stop() {
+        running = false;
+        if (task != null) task.cancel();
+    }
+
+    // ── Per-tick logic ────────────────────────────────────────────────────
+
+    private void tick() {
+        if (!running) return;
+        Player target = plugin.getServer().getPlayer(targetUuid);
+        if (target == null || !target.isOnline()) {
+            stop();
+            return;
+        }
+        if (bot.isDead() || !bot.entity().isValid()) {
+            stop();
+            return;
+        }
+
+        tickCount++;
+
+        // Flip strafe every STRAFE_FLIP_TICKS ticks
+        if (tickCount % STRAFE_FLIP_TICKS == 0) {
+            strafeDirection = -strafeDirection;
+        }
+
+        Location botLoc    = bot.location();
+        Location targetLoc = target.getLocation();
+        double dist = botLoc.distance(targetLoc);
+
+        // ── Attack ────────────────────────────────────────────────────────
+        if (tickCount % settings.botAttackIntervalTicks() == 0 && dist <= IDEAL_DISTANCE + 0.8) {
+            target.damage(settings.botAttackDamage());
+            bot.playAttackEffect(targetLoc);
+        }
+
+        // ── Retreat if low HP ─────────────────────────────────────────────
+        double maxHp = BotOpponent.MAX_HEALTH;
+        if (bot.getHealth() / maxHp < RETREAT_HP_FRAC && retreatTicks == 0) {
+            retreatTicks = 20; // retreat for 1 second
+        }
+        if (retreatTicks > 0) {
+            retreatTicks -= 2; // decremented every 2-tick cycle
+            moveAwayFrom(botLoc, targetLoc);
+            return;
+        }
+
+        // ── Approach + strafe ─────────────────────────────────────────────
+        if (dist > STOP_DISTANCE) {
+            moveToward(botLoc, targetLoc, dist);
+        }
+        bot.lookAt(targetLoc);
+    }
+
+    // ── Movement helpers ──────────────────────────────────────────────────
+
+    private void moveToward(Location from, Location target, double dist) {
+        double dx = target.getX() - from.getX();
+        double dz = target.getZ() - from.getZ();
+        // Normalize horizontal direction
+        double len = Math.sqrt(dx * dx + dz * dz);
+        if (len < 0.001) return;
+        dx /= len;
+        dz /= len;
+
+        // Perpendicular strafe component
+        double sx = -dz * strafeDirection * 0.3;
+        double sz =  dx * strafeDirection * 0.3;
+
+        double speed = settings.botMoveSpeed();
+        if (dist < IDEAL_DISTANCE + 0.5) speed *= 0.5; // slow down near target
+
+        double newX = from.getX() + (dx + sx) * speed;
+        double newZ = from.getZ() + (dz + sz) * speed;
+
+        Location dest = from.clone();
+        dest.setX(newX);
+        dest.setZ(newZ);
+        // Inherit yaw toward target
+        double ydx = target.getX() - newX;
+        double ydz = target.getZ() - newZ;
+        dest.setYaw((float) Math.toDegrees(Math.atan2(-ydx, ydz)));
+
+        bot.moveTo(dest);
+    }
+
+    private void moveAwayFrom(Location from, Location threat) {
+        double dx = from.getX() - threat.getX();
+        double dz = from.getZ() - threat.getZ();
+        double len = Math.sqrt(dx * dx + dz * dz);
+        if (len < 0.001) return;
+        dx /= len;
+        dz /= len;
+
+        double newX = from.getX() + dx * settings.botMoveSpeed() * 1.4;
+        double newZ = from.getZ() + dz * settings.botMoveSpeed() * 1.4;
+        Location dest = from.clone();
+        dest.setX(newX);
+        dest.setZ(newZ);
+        bot.moveTo(dest);
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────
+
+    public boolean isRunning() { return running; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotNmsAdapter.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotNmsAdapter.java
@@ -1,0 +1,41 @@
+package com.pvpindex.battles.practice.bot;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Version-specific NMS adapter for spawning a headless fake-player entity.
+ *
+ * <p>Implementations live in the version-specific {@code paper-versions} modules
+ * and are loaded at start-up via {@code Class.forName} in the bootstrap plugin.
+ * The currently registered adapter is injected into {@link BotPlayerFactory} via
+ * {@link BotPlayerFactory#setNmsAdapter}.</p>
+ *
+ * <p>Platform support:</p>
+ * <ul>
+ *   <li><b>Paper 1.21.x</b> — {@code BotNmsAdapter121} (no ServerWaypointManager)</li>
+ *   <li><b>Paper 26.1.x</b> — {@code BotNmsAdapter2610} (ServerWaypointManager cleanup)</li>
+ *   <li><b>Spigot 1.21.x</b> — {@code BotNmsAdapter121} works (same NMS classes)</li>
+ *   <li><b>Folia</b>         — no adapter loaded; Zombie fallback always used</li>
+ * </ul>
+ *
+ * <p>Each implementation guarantees that any partial NMS state (entity tracking,
+ * {@code PlayerList}, {@code ServerWaypointManager}) is cleaned up before returning
+ * {@code null} or re-throwing an exception.</p>
+ */
+public interface BotNmsAdapter {
+
+    /**
+     * Attempts to spawn a headless NMS {@code ServerPlayer} at {@code location}.
+     *
+     * @param world    the target world
+     * @param location spawn position
+     * @param name     display name (≤ 16 chars for most NMS versions)
+     * @return the Bukkit {@link LivingEntity} wrapping the fake player on success,
+     *         or {@code null} if NMS spawning is not supported on this version
+     * @throws Exception if a recoverable failure occurred; the implementation must
+     *                   clean up all partial NMS state before re-throwing
+     */
+    LivingEntity spawnFakePlayer(World world, Location location, String name) throws Exception;
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotOpponent.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotOpponent.java
@@ -1,0 +1,172 @@
+package com.pvpindex.battles.practice.bot;
+
+import com.pvpindex.battles.gamemode.KitApplier;
+import com.pvpindex.battles.gamemode.KitDefinition;
+import java.lang.reflect.Method;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Thin wrapper around the bot entity spawned by {@link BotPlayerFactory}.
+ *
+ * <p>Provides a clean API for the rest of the practice system without leaking
+ * the NMS-vs-Zombie distinction.  When the underlying entity is a fake NMS
+ * {@link Player}, movement is performed via reflection on the NMS
+ * {@code setPos()} method (connection-safe).  For a {@link org.bukkit.entity.Zombie}
+ * fallback, standard {@code entity.teleport()} is used.</p>
+ */
+public final class BotOpponent {
+
+    static final double MAX_HEALTH = 20.0;
+
+    private final LivingEntity entity;
+    /** Cached NMS entity handle for connection-free position updates. */
+    private Object nmsHandle;
+
+    public BotOpponent(LivingEntity entity) {
+        this.entity = entity;
+        cacheNmsHandle();
+    }
+
+    // ── Setup ─────────────────────────────────────────────────────────────
+
+    /**
+     * Apply a {@link KitDefinition} to the bot entity.
+     *
+     * <p>For fake-player entities (no real connection) we set equipment via
+     * the NMS-level equipment slots when possible, falling back to the Bukkit
+     * {@link EntityEquipment} API which still works for inventory storage
+     * even without a connection for the client-visible sync (entity tracker
+     * will broadcast the equipment on the next tracking interval).</p>
+     */
+    public void applyKit(KitDefinition kit, KitApplier kitApplier) {
+        if (entity instanceof Player player) {
+            kitApplier.apply(player, kit);
+        } else {
+            // Zombie fallback – set equipment directly
+            EntityEquipment eq = entity.getEquipment();
+            if (eq == null) return;
+            eq.setItemInMainHand(new ItemStack(Material.IRON_SWORD));
+            eq.setHelmet(new ItemStack(Material.IRON_HELMET));
+            eq.setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
+            eq.setLeggings(new ItemStack(Material.IRON_LEGGINGS));
+            eq.setBoots(new ItemStack(Material.IRON_BOOTS));
+            eq.setItemInMainHandDropChance(0f);
+            eq.setHelmetDropChance(0f);
+            eq.setChestplateDropChance(0f);
+            eq.setLeggingsDropChance(0f);
+            eq.setBootsDropChance(0f);
+        }
+        resetHealth();
+    }
+
+    /** Restore the bot to full health. */
+    public void resetHealth() {
+        try {
+            var attr = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+            if (attr != null) attr.setBaseValue(MAX_HEALTH);
+        } catch (Exception ignored) {}
+        entity.setHealth(MAX_HEALTH);
+    }
+
+    // ── Movement ──────────────────────────────────────────────────────────
+
+    /**
+     * Move the bot to a new location.
+     *
+     * <p>For a fake NMS player (no connection) calling {@code player.teleport()}
+     * would NPE when trying to send the teleport packet.  We instead call
+     * {@code ServerPlayer.setPos()} directly via the cached NMS handle,
+     * which updates the server-side position; the entity tracker then
+     * broadcasts a position-sync packet on the next tick automatically.</p>
+     */
+    public void moveTo(Location loc) {
+        if (nmsHandle != null) {
+            try {
+                nmsHandle.getClass()
+                        .getMethod("setPos", double.class, double.class, double.class)
+                        .invoke(nmsHandle, loc.getX(), loc.getY(), loc.getZ());
+                // Update yaw / pitch
+                nmsHandle.getClass().getMethod("setYRot", float.class).invoke(nmsHandle, loc.getYaw());
+                nmsHandle.getClass().getMethod("setXRot", float.class).invoke(nmsHandle, loc.getPitch());
+                try {
+                    nmsHandle.getClass().getMethod("setYBodyRot", float.class)
+                            .invoke(nmsHandle, loc.getYaw());
+                } catch (Exception ignored) {}
+                return;
+            } catch (Exception e) {
+                nmsHandle = null; // invalidate cache, fall through to Bukkit teleport
+            }
+        }
+        // Bukkit fallback (Zombie or NMS fallback)
+        entity.teleport(loc);
+    }
+
+    /** Make the entity look at {@code target}. */
+    public void lookAt(Location target) {
+        Location current = entity.getLocation();
+        double dx = target.getX() - current.getX();
+        double dz = target.getZ() - current.getZ();
+        double dy = target.getY() - current.getY() + 1.0;
+        double dist = Math.sqrt(dx * dx + dz * dz);
+
+        float yaw   = (float) (Math.toDegrees(Math.atan2(-dx, dz)));
+        float pitch = (float) (-Math.toDegrees(Math.atan2(dy, dist)));
+
+        Location looked = current.clone();
+        looked.setYaw(yaw);
+        looked.setPitch(pitch);
+        moveTo(looked);
+    }
+
+    // ── Combat ────────────────────────────────────────────────────────────
+
+    public double getHealth()                   { return entity.getHealth(); }
+    public void setHealth(double hp)            { entity.setHealth(Math.max(0, hp)); }
+    public boolean isDead()                     { return !entity.isValid() || entity.isDead() || entity.getHealth() <= 0; }
+
+    /** Play the bot's melee-attack swing sounds and particles near {@code target}. */
+    public void playAttackEffect(Location target) {
+        var world = target.getWorld();
+        if (world == null) return;
+        world.playSound(target, org.bukkit.Sound.ENTITY_PLAYER_ATTACK_STRONG, 0.9f, 1.0f);
+        world.spawnParticle(org.bukkit.Particle.CRIT, target.add(0, 1, 0), 6, 0.2, 0.2, 0.2, 0.05);
+    }
+
+    // ── Cleanup ───────────────────────────────────────────────────────────
+
+    /** Remove the bot entity from the world. */
+    public void remove() {
+        if (entity.isValid()) {
+            entity.remove();
+        }
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────
+
+    public LivingEntity entity()    { return entity; }
+    public UUID entityUuid()        { return entity.getUniqueId(); }
+    public Location location()      { return entity.getLocation(); }
+    public boolean isNmsPlayer()    { return entity instanceof Player; }
+
+    // ── Internal ─────────────────────────────────────────────────────────
+
+    /** Cache the NMS entity handle (if accessible) for connection-free movement. */
+    private void cacheNmsHandle() {
+        if (!(entity instanceof Player)) return; // only needed for fake-player
+        try {
+            nmsHandle = entity.getClass().getMethod("getHandle").invoke(entity);
+        } catch (Exception e) {
+            nmsHandle = null;
+        }
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
@@ -1,8 +1,10 @@
 package com.pvpindex.battles.practice.bot;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
@@ -59,6 +61,10 @@ public final class BotPlayerFactory {
                 plugin.getLogger().warning("[PracticeBot] NMS fake-player spawn failed ("
                         + e.getClass().getSimpleName() + ": " + e.getMessage()
                         + "). Falling back to Zombie bot.");
+                // The ServerPlayer ctor may partially register itself in PlayerList before
+                // throwing, leaving a null-connection entry that causes an NPE inside
+                // PlayerList.broadcastAll() on the very next server tick.  Remove it now.
+                tryPurgeNullConnectionPlayers(plugin.getLogger());
             }
         }
         return spawnZombieFallback(world, location, name);
@@ -184,6 +190,64 @@ public final class BotPlayerFactory {
             }
         }
         throw new NoSuchMethodException("addFreshEntity not found on " + nmsLevel.getClass().getSimpleName());
+    }
+
+    // ── NMS cleanup ───────────────────────────────────────────────────────────
+
+    /**
+     * Reflectively removes any {@code ServerPlayer} with a null {@code connection}
+     * field from the server's {@code PlayerList.players} list.
+     *
+     * <p>This guards against a crash in {@code PlayerList.broadcastAll()} that
+     * occurs when the {@code ServerPlayer} constructor partially registers the
+     * entity before throwing, leaving a disconnected entry behind.</p>
+     */
+    private static void tryPurgeNullConnectionPlayers(Logger logger) {
+        try {
+            Object craftServer = Bukkit.getServer();
+            Object nmsServer   = craftServer.getClass().getMethod("getServer").invoke(craftServer);
+            Object playerList  = nmsServer.getClass().getMethod("getPlayerList").invoke(nmsServer);
+
+            // Walk up the class hierarchy to find the "players" List field
+            Field playersField = null;
+            for (Class<?> c = playerList.getClass(); c != null && playersField == null; c = c.getSuperclass()) {
+                try { playersField = c.getDeclaredField("players"); } catch (NoSuchFieldException ignored) {}
+            }
+            if (playersField == null) return;
+            playersField.setAccessible(true);
+
+            @SuppressWarnings("unchecked")
+            java.util.List<Object> players = (java.util.List<Object>) playersField.get(playerList);
+            int removed = 0;
+            Iterator<Object> it = players.iterator();
+            while (it.hasNext()) {
+                Object p = it.next();
+                if (p == null || hasNullConnection(p)) {
+                    it.remove();
+                    removed++;
+                }
+            }
+            if (removed > 0) {
+                logger.warning("[PracticeBot] Purged " + removed
+                        + " null-connection player(s) from PlayerList to prevent NPE crash.");
+            }
+        } catch (Exception ex) {
+            logger.warning("[PracticeBot] Could not purge null-connection players: " + ex.getMessage());
+        }
+    }
+
+    private static boolean hasNullConnection(Object serverPlayer) {
+        try {
+            Field connField = null;
+            for (Class<?> c = serverPlayer.getClass(); c != null && connField == null; c = c.getSuperclass()) {
+                try { connField = c.getDeclaredField("connection"); } catch (NoSuchFieldException ignored) {}
+            }
+            if (connField == null) return false;
+            connField.setAccessible(true);
+            return connField.get(serverPlayer) == null;
+        } catch (Exception ex) {
+            return false;
+        }
     }
 
     // ── Zombie fallback ───────────────────────────────────────────────────────

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.UUID;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
@@ -218,15 +217,12 @@ public final class BotPlayerFactory {
 
             @SuppressWarnings("unchecked")
             java.util.List<Object> players = (java.util.List<Object>) playersField.get(playerList);
-            int removed = 0;
-            Iterator<Object> it = players.iterator();
-            while (it.hasNext()) {
-                Object p = it.next();
-                if (p == null || hasNullConnection(p)) {
-                    it.remove();
-                    removed++;
-                }
-            }
+            int before = players.size();
+            // CopyOnWriteArrayList (used by Paper's PlayerList) does NOT support
+            // Iterator.remove() — it throws UnsupportedOperationException.
+            // removeIf() uses the list's own bulk-remove path, which is safe.
+            players.removeIf(p -> p == null || hasNullConnection(p));
+            int removed = before - players.size();
             if (removed > 0) {
                 logger.warning("[PracticeBot] Purged " + removed
                         + " null-connection player(s) from PlayerList to prevent NPE crash.");

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
@@ -1,0 +1,201 @@
+package com.pvpindex.battles.practice.bot;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Creates the bot entity for a {@link BotSession}.
+ *
+ * <p>When {@code useNms=true}, an NMS {@code ServerPlayer} is constructed via
+ * reflection (works on Paper 1.20.5 + / 26.1 where CraftBukkit dropped the
+ * versioned package prefix).  The returned Bukkit {@link Player} is a fully
+ * valid entity in the world — it is visible to clients, equippable, and
+ * damageable — but it has no network connection, so the server never tries to
+ * send it movement confirmations.  All position updates are driven by
+ * {@link BotBehaviorTask} using the {@code Entity.setPos()} NMS method.</p>
+ *
+ * <p>If NMS reflection fails for any reason the factory falls back to a
+ * {@link Zombie} entity with custom equipment, which behaves identically from
+ * the combat perspective while looking like a geared opponent.</p>
+ */
+public final class BotPlayerFactory {
+
+    private BotPlayerFactory() {}
+
+    /**
+     * Spawn the bot entity at {@code location}.
+     *
+     * @param plugin   owning plugin (for logging)
+     * @param world    target world
+     * @param location spawn location
+     * @param name     display name shown above the entity
+     * @param useNms   if {@code true} attempt NMS fake-player first
+     * @return a {@link LivingEntity} (either a fake {@link Player} or a
+     *         {@link Zombie} fallback) that is already added to the world
+     */
+    public static LivingEntity spawn(Plugin plugin, World world, Location location,
+            String name, boolean useNms) {
+        if (useNms) {
+            try {
+                LivingEntity fakePlayer = spawnViaNms(world, location, name);
+                if (fakePlayer != null) {
+                    plugin.getLogger().info("[PracticeBot] Spawned NMS fake-player bot '" + name + "'.");
+                    return fakePlayer;
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("[PracticeBot] NMS fake-player spawn failed ("
+                        + e.getClass().getSimpleName() + ": " + e.getMessage()
+                        + "). Falling back to Zombie bot.");
+            }
+        }
+        return spawnZombieFallback(world, location, name);
+    }
+
+    // ── NMS ServerPlayer ─────────────────────────────────────────────────────
+
+    /**
+     * Uses reflection to construct a headless {@code net.minecraft.server.level.ServerPlayer}
+     * and add it to the world's entity list.  Tested on Paper 1.21.x and 26.1.x
+     * (post-package-rename era where CraftBukkit lives in
+     * {@code org.bukkit.craftbukkit.*} without a version suffix).
+     */
+    private static LivingEntity spawnViaNms(World world, Location location, String name)
+            throws Exception {
+
+        // 1 ── MinecraftServer ────────────────────────────────────────────
+        Object craftServer = Bukkit.getServer();
+        Object nmsServer = craftServer.getClass()
+                .getMethod("getServer")
+                .invoke(craftServer);
+
+        // 2 ── ServerLevel ────────────────────────────────────────────────
+        Object nmsLevel = world.getClass()
+                .getMethod("getHandle")
+                .invoke(world);
+
+        // 3 ── GameProfile (com.mojang.authlib bundled at runtime with Paper) ─
+        UUID botUuid = UUID.nameUUIDFromBytes(
+                ("PracticeBot:" + name).getBytes(StandardCharsets.UTF_8));
+        // Use reflection so we don't need a compile-time dependency on authlib
+        Class<?> gameProfileClass = Class.forName("com.mojang.authlib.GameProfile");
+        Object profile = gameProfileClass
+                .getConstructor(UUID.class, String.class)
+                .newInstance(botUuid, name);
+
+        // 4 ── ClientInformation.createDefault() ─────────────────────────
+        Object clientInfo = resolveClientInformationDefault();
+        if (clientInfo == null) {
+            throw new UnsupportedOperationException("ClientInformation.createDefault() not found");
+        }
+
+        // 5 ── ServerPlayer constructor ───────────────────────────────────
+        Class<?> serverPlayerClass = Class.forName("net.minecraft.server.level.ServerPlayer");
+        Constructor<?> ctor = resolveServerPlayerConstructor(serverPlayerClass,
+                nmsServer, nmsLevel, clientInfo);
+        Object bot = ctor.newInstance(nmsServer, nmsLevel, profile, clientInfo);
+
+        // 6 ── Set initial position ───────────────────────────────────────
+        bot.getClass()
+                .getMethod("setPos", double.class, double.class, double.class)
+                .invoke(bot, location.getX(), location.getY(), location.getZ());
+
+        // 7 ── Add to world (triggers entity tracker → sends spawn packet) ─
+        addFreshEntityReflective(nmsLevel, bot);
+
+        // 8 ── Return as Bukkit entity ────────────────────────────────────
+        Object bukkitEntity = bot.getClass().getMethod("getBukkitEntity").invoke(bot);
+        if (bukkitEntity instanceof LivingEntity le) {
+            return le;
+        }
+        throw new IllegalStateException("getBukkitEntity() did not return a LivingEntity");
+    }
+
+    /**
+     * Searches for {@code ClientInformation.createDefault()} across the known
+     * class locations that differ between Paper 1.21.x and 26.1.x.
+     */
+    private static Object resolveClientInformationDefault() {
+        String[] candidates = {
+            "net.minecraft.server.level.ClientInformation",
+            "net.minecraft.network.protocol.game.ClientboundLoginPacket$ClientInformation",
+            "net.minecraft.server.network.ClientInformation"
+        };
+        for (String className : candidates) {
+            try {
+                Class<?> cls = Class.forName(className);
+                Method m = cls.getDeclaredMethod("createDefault");
+                m.setAccessible(true);
+                Object result = m.invoke(null);
+                if (result != null) return result;
+            } catch (Exception ignored) {}
+        }
+        return null;
+    }
+
+    /**
+     * Finds the {@code ServerPlayer} constructor that accepts
+     * (MinecraftServer, ServerLevel, GameProfile, ClientInformation).
+     */
+    private static Constructor<?> resolveServerPlayerConstructor(
+            Class<?> serverPlayerClass, Object nmsServer, Object nmsLevel, Object clientInfo)
+            throws NoSuchMethodException {
+        // Walk all public constructors and pick the 4-param one
+        for (Constructor<?> c : serverPlayerClass.getDeclaredConstructors()) {
+            if (c.getParameterCount() == 4) {
+                c.setAccessible(true);
+                return c;
+            }
+        }
+        throw new NoSuchMethodException("No 4-param constructor found on ServerPlayer");
+    }
+
+    /**
+     * Reflectively calls {@code ServerLevel.addFreshEntity(Entity)} (Paper 1.21+)
+     * or the equivalent method on the supplied {@code nmsLevel}.
+     */
+    private static void addFreshEntityReflective(Object nmsLevel, Object bot) throws Exception {
+        // addFreshEntity(Entity, SpawnReason?) - try 1-param version first
+        for (Method m : nmsLevel.getClass().getMethods()) {
+            if (m.getName().equals("addFreshEntity") && m.getParameterCount() == 1) {
+                m.invoke(nmsLevel, bot);
+                return;
+            }
+        }
+        // 2-param version with SpawnReason
+        for (Method m : nmsLevel.getClass().getMethods()) {
+            if (m.getName().equals("addFreshEntity") && m.getParameterCount() == 2) {
+                // second param is SpawnReason enum – pass the DEFAULT value
+                Object defaultReason = m.getParameterTypes()[1].getEnumConstants()[0];
+                m.invoke(nmsLevel, bot, defaultReason);
+                return;
+            }
+        }
+        throw new NoSuchMethodException("addFreshEntity not found on " + nmsLevel.getClass().getSimpleName());
+    }
+
+    // ── Zombie fallback ───────────────────────────────────────────────────────
+
+    private static LivingEntity spawnZombieFallback(World world, Location location, String name) {
+        Zombie zombie = (Zombie) world.spawnEntity(location, EntityType.ZOMBIE);
+        zombie.setAI(false); // manual AI via BotBehaviorTask
+        zombie.customName(net.kyori.adventure.text.Component.text(name,
+                net.kyori.adventure.text.format.NamedTextColor.GOLD));
+        zombie.setCustomNameVisible(true);
+        zombie.setRemoveWhenFarAway(false);
+        zombie.setBaby(false);
+        return zombie;
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotPlayerFactory.java
@@ -1,40 +1,50 @@
 package com.pvpindex.battles.practice.bot;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
 import org.bukkit.entity.Zombie;
 import org.bukkit.plugin.Plugin;
 
 /**
  * Creates the bot entity for a {@link BotSession}.
  *
- * <p>When {@code useNms=true}, an NMS {@code ServerPlayer} is constructed via
- * reflection (works on Paper 1.20.5 + / 26.1 where CraftBukkit dropped the
- * versioned package prefix).  The returned Bukkit {@link Player} is a fully
- * valid entity in the world — it is visible to clients, equippable, and
- * damageable — but it has no network connection, so the server never tries to
- * send it movement confirmations.  All position updates are driven by
- * {@link BotBehaviorTask} using the {@code Entity.setPos()} NMS method.</p>
+ * <p>NMS-based fake-player spawning is delegated to a {@link BotNmsAdapter} that
+ * is registered once at start-up via {@link #setNmsAdapter}.  The correct adapter
+ * is chosen by the bootstrap based on the detected Minecraft version:</p>
+ * <ul>
+ *   <li><b>Paper / Spigot 1.21.x</b> → {@code BotNmsAdapter121}</li>
+ *   <li><b>Paper 26.1.x</b>          → {@code BotNmsAdapter2610}</li>
+ *   <li><b>Folia (any version)</b>   → no adapter; Zombie fallback always used</li>
+ * </ul>
  *
- * <p>If NMS reflection fails for any reason the factory falls back to a
- * {@link Zombie} entity with custom equipment, which behaves identically from
- * the combat perspective while looking like a geared opponent.</p>
+ * <p>If no adapter is available, or if the NMS spawn fails for any reason, a
+ * {@link Zombie} entity is used as a functionally equivalent fallback.</p>
  */
 public final class BotPlayerFactory {
 
+    /**
+     * Platform-specific NMS adapter injected by the bootstrap plugin.
+     * {@code null} when NMS fake-players are unsupported (Folia) or when
+     * {@code botUseNms} is disabled in {@code practice.yml}.
+     */
+    private static volatile BotNmsAdapter nmsAdapter = null;
+
     private BotPlayerFactory() {}
+
+    /**
+     * Registers the platform-specific NMS adapter.
+     * Must be called from the main thread before any bot session is started.
+     *
+     * @param adapter the adapter to use, or {@code null} to disable NMS spawning
+     */
+    public static void setNmsAdapter(BotNmsAdapter adapter) {
+        nmsAdapter = adapter;
+    }
 
     /**
      * Spawn the bot entity at {@code location}.
@@ -43,163 +53,51 @@ public final class BotPlayerFactory {
      * @param world    target world
      * @param location spawn location
      * @param name     display name shown above the entity
-     * @param useNms   if {@code true} attempt NMS fake-player first
-     * @return a {@link LivingEntity} (either a fake {@link Player} or a
+     * @param useNms   if {@code true} and an adapter is installed, attempt NMS fake-player first
+     * @return a {@link LivingEntity} (either a fake {@link org.bukkit.entity.Player} or a
      *         {@link Zombie} fallback) that is already added to the world
      */
     public static LivingEntity spawn(Plugin plugin, World world, Location location,
             String name, boolean useNms) {
         if (useNms) {
-            try {
-                LivingEntity fakePlayer = spawnViaNms(world, location, name);
-                if (fakePlayer != null) {
-                    plugin.getLogger().info("[PracticeBot] Spawned NMS fake-player bot '" + name + "'.");
-                    return fakePlayer;
+            BotNmsAdapter adapter = nmsAdapter; // volatile read — safe without sync
+            if (adapter != null) {
+                try {
+                    LivingEntity fakePlayer = adapter.spawnFakePlayer(world, location, name);
+                    if (fakePlayer != null) {
+                        plugin.getLogger().info(
+                                "[PracticeBot] Spawned NMS fake-player bot '" + name + "'.");
+                        return fakePlayer;
+                    }
+                } catch (Exception e) {
+                    plugin.getLogger().warning(
+                            "[PracticeBot] NMS fake-player spawn failed ("
+                            + e.getClass().getSimpleName() + ": " + e.getMessage()
+                            + "). Falling back to Zombie bot.");
+                    // Secondary safety net: the adapter already called tryRemoveEntity,
+                    // but purge any lingering null-connection entry from PlayerList to
+                    // guard against PlayerList.broadcastAll() NPE on the next server tick.
+                    tryPurgeNullConnectionPlayers(plugin.getLogger());
                 }
-            } catch (Exception e) {
-                plugin.getLogger().warning("[PracticeBot] NMS fake-player spawn failed ("
-                        + e.getClass().getSimpleName() + ": " + e.getMessage()
-                        + "). Falling back to Zombie bot.");
-                // The ServerPlayer ctor may partially register itself in PlayerList before
-                // throwing, leaving a null-connection entry that causes an NPE inside
-                // PlayerList.broadcastAll() on the very next server tick.  Remove it now.
-                tryPurgeNullConnectionPlayers(plugin.getLogger());
+            } else {
+                plugin.getLogger().fine(
+                        "[PracticeBot] NMS bot requested but no adapter is available "
+                        + "(Folia or unsupported version). Using Zombie fallback.");
             }
         }
         return spawnZombieFallback(world, location, name);
     }
 
-    // ── NMS ServerPlayer ─────────────────────────────────────────────────────
+    // ── Secondary safety net ──────────────────────────────────────────────────
 
     /**
-     * Uses reflection to construct a headless {@code net.minecraft.server.level.ServerPlayer}
-     * and add it to the world's entity list.  Tested on Paper 1.21.x and 26.1.x
-     * (post-package-rename era where CraftBukkit lives in
-     * {@code org.bukkit.craftbukkit.*} without a version suffix).
-     */
-    private static LivingEntity spawnViaNms(World world, Location location, String name)
-            throws Exception {
-
-        // 1 ── MinecraftServer ────────────────────────────────────────────
-        Object craftServer = Bukkit.getServer();
-        Object nmsServer = craftServer.getClass()
-                .getMethod("getServer")
-                .invoke(craftServer);
-
-        // 2 ── ServerLevel ────────────────────────────────────────────────
-        Object nmsLevel = world.getClass()
-                .getMethod("getHandle")
-                .invoke(world);
-
-        // 3 ── GameProfile (com.mojang.authlib bundled at runtime with Paper) ─
-        UUID botUuid = UUID.nameUUIDFromBytes(
-                ("PracticeBot:" + name).getBytes(StandardCharsets.UTF_8));
-        // Use reflection so we don't need a compile-time dependency on authlib
-        Class<?> gameProfileClass = Class.forName("com.mojang.authlib.GameProfile");
-        Object profile = gameProfileClass
-                .getConstructor(UUID.class, String.class)
-                .newInstance(botUuid, name);
-
-        // 4 ── ClientInformation.createDefault() ─────────────────────────
-        Object clientInfo = resolveClientInformationDefault();
-        if (clientInfo == null) {
-            throw new UnsupportedOperationException("ClientInformation.createDefault() not found");
-        }
-
-        // 5 ── ServerPlayer constructor ───────────────────────────────────
-        Class<?> serverPlayerClass = Class.forName("net.minecraft.server.level.ServerPlayer");
-        Constructor<?> ctor = resolveServerPlayerConstructor(serverPlayerClass,
-                nmsServer, nmsLevel, clientInfo);
-        Object bot = ctor.newInstance(nmsServer, nmsLevel, profile, clientInfo);
-
-        // 6 ── Set initial position ───────────────────────────────────────
-        bot.getClass()
-                .getMethod("setPos", double.class, double.class, double.class)
-                .invoke(bot, location.getX(), location.getY(), location.getZ());
-
-        // 7 ── Add to world (triggers entity tracker → sends spawn packet) ─
-        addFreshEntityReflective(nmsLevel, bot);
-
-        // 8 ── Return as Bukkit entity ────────────────────────────────────
-        Object bukkitEntity = bot.getClass().getMethod("getBukkitEntity").invoke(bot);
-        if (bukkitEntity instanceof LivingEntity le) {
-            return le;
-        }
-        throw new IllegalStateException("getBukkitEntity() did not return a LivingEntity");
-    }
-
-    /**
-     * Searches for {@code ClientInformation.createDefault()} across the known
-     * class locations that differ between Paper 1.21.x and 26.1.x.
-     */
-    private static Object resolveClientInformationDefault() {
-        String[] candidates = {
-            "net.minecraft.server.level.ClientInformation",
-            "net.minecraft.network.protocol.game.ClientboundLoginPacket$ClientInformation",
-            "net.minecraft.server.network.ClientInformation"
-        };
-        for (String className : candidates) {
-            try {
-                Class<?> cls = Class.forName(className);
-                Method m = cls.getDeclaredMethod("createDefault");
-                m.setAccessible(true);
-                Object result = m.invoke(null);
-                if (result != null) return result;
-            } catch (Exception ignored) {}
-        }
-        return null;
-    }
-
-    /**
-     * Finds the {@code ServerPlayer} constructor that accepts
-     * (MinecraftServer, ServerLevel, GameProfile, ClientInformation).
-     */
-    private static Constructor<?> resolveServerPlayerConstructor(
-            Class<?> serverPlayerClass, Object nmsServer, Object nmsLevel, Object clientInfo)
-            throws NoSuchMethodException {
-        // Walk all public constructors and pick the 4-param one
-        for (Constructor<?> c : serverPlayerClass.getDeclaredConstructors()) {
-            if (c.getParameterCount() == 4) {
-                c.setAccessible(true);
-                return c;
-            }
-        }
-        throw new NoSuchMethodException("No 4-param constructor found on ServerPlayer");
-    }
-
-    /**
-     * Reflectively calls {@code ServerLevel.addFreshEntity(Entity)} (Paper 1.21+)
-     * or the equivalent method on the supplied {@code nmsLevel}.
-     */
-    private static void addFreshEntityReflective(Object nmsLevel, Object bot) throws Exception {
-        // addFreshEntity(Entity, SpawnReason?) - try 1-param version first
-        for (Method m : nmsLevel.getClass().getMethods()) {
-            if (m.getName().equals("addFreshEntity") && m.getParameterCount() == 1) {
-                m.invoke(nmsLevel, bot);
-                return;
-            }
-        }
-        // 2-param version with SpawnReason
-        for (Method m : nmsLevel.getClass().getMethods()) {
-            if (m.getName().equals("addFreshEntity") && m.getParameterCount() == 2) {
-                // second param is SpawnReason enum – pass the DEFAULT value
-                Object defaultReason = m.getParameterTypes()[1].getEnumConstants()[0];
-                m.invoke(nmsLevel, bot, defaultReason);
-                return;
-            }
-        }
-        throw new NoSuchMethodException("addFreshEntity not found on " + nmsLevel.getClass().getSimpleName());
-    }
-
-    // ── NMS cleanup ───────────────────────────────────────────────────────────
-
-    /**
-     * Reflectively removes any {@code ServerPlayer} with a null {@code connection}
-     * field from the server's {@code PlayerList.players} list.
+     * Reflectively removes any {@code ServerPlayer} with a {@code null} connection
+     * from {@code PlayerList.players}.
      *
-     * <p>This guards against a crash in {@code PlayerList.broadcastAll()} that
-     * occurs when the {@code ServerPlayer} constructor partially registers the
-     * entity before throwing, leaving a disconnected entry behind.</p>
+     * <p>This is a secondary guard against {@code PlayerList.broadcastAll()} NPE
+     * in case the adapter's {@link NmsSpawnHelper#tryRemoveEntity} cleanup was
+     * incomplete.  Uses {@code removeIf()} which is safe on
+     * {@code CopyOnWriteArrayList} (unlike {@code Iterator.remove()}).</p>
      */
     private static void tryPurgeNullConnectionPlayers(Logger logger) {
         try {
@@ -207,20 +105,19 @@ public final class BotPlayerFactory {
             Object nmsServer   = craftServer.getClass().getMethod("getServer").invoke(craftServer);
             Object playerList  = nmsServer.getClass().getMethod("getPlayerList").invoke(nmsServer);
 
-            // Walk up the class hierarchy to find the "players" List field
             Field playersField = null;
-            for (Class<?> c = playerList.getClass(); c != null && playersField == null; c = c.getSuperclass()) {
-                try { playersField = c.getDeclaredField("players"); } catch (NoSuchFieldException ignored) {}
+            for (Class<?> c = playerList.getClass(); c != null && playersField == null;
+                    c = c.getSuperclass()) {
+                try { playersField = c.getDeclaredField("players"); }
+                catch (NoSuchFieldException ignored) {}
             }
             if (playersField == null) return;
             playersField.setAccessible(true);
 
             @SuppressWarnings("unchecked")
-            java.util.List<Object> players = (java.util.List<Object>) playersField.get(playerList);
+            java.util.List<Object> players =
+                    (java.util.List<Object>) playersField.get(playerList);
             int before = players.size();
-            // CopyOnWriteArrayList (used by Paper's PlayerList) does NOT support
-            // Iterator.remove() — it throws UnsupportedOperationException.
-            // removeIf() uses the list's own bulk-remove path, which is safe.
             players.removeIf(p -> p == null || hasNullConnection(p));
             int removed = before - players.size();
             if (removed > 0) {
@@ -228,20 +125,23 @@ public final class BotPlayerFactory {
                         + " null-connection player(s) from PlayerList to prevent NPE crash.");
             }
         } catch (Exception ex) {
-            logger.warning("[PracticeBot] Could not purge null-connection players: " + ex.getMessage());
+            logger.warning("[PracticeBot] Could not purge null-connection players: "
+                    + ex.getMessage());
         }
     }
 
     private static boolean hasNullConnection(Object serverPlayer) {
         try {
             Field connField = null;
-            for (Class<?> c = serverPlayer.getClass(); c != null && connField == null; c = c.getSuperclass()) {
-                try { connField = c.getDeclaredField("connection"); } catch (NoSuchFieldException ignored) {}
+            for (Class<?> c = serverPlayer.getClass(); c != null && connField == null;
+                    c = c.getSuperclass()) {
+                try { connField = c.getDeclaredField("connection"); }
+                catch (NoSuchFieldException ignored) {}
             }
             if (connField == null) return false;
             connField.setAccessible(true);
             return connField.get(serverPlayer) == null;
-        } catch (Exception ex) {
+        } catch (Exception ignored) {
             return false;
         }
     }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotSession.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotSession.java
@@ -1,0 +1,100 @@
+package com.pvpindex.battles.practice.bot;
+
+import com.pvpindex.battles.gamemode.KitApplier;
+import com.pvpindex.battles.gamemode.KitDefinition;
+import com.pvpindex.battles.practice.PracticeSettings;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.time.Duration;
+
+/**
+ * Lifecycle manager for a single bot-duel practice session.
+ *
+ * <p>Call {@link #spawn(Plugin, Player, Location, KitDefinition, KitApplier, PracticeSettings)}
+ * to create and start the session, then {@link #end(boolean)} when the duel is
+ * finished (either the bot or the player died).</p>
+ */
+public final class BotSession {
+
+    private final BotOpponent opponent;
+    private final BotBehaviorTask behaviorTask;
+    private final Player target;
+    private boolean ended = false;
+
+    private BotSession(BotOpponent opponent, BotBehaviorTask behaviorTask, Player target) {
+        this.opponent     = opponent;
+        this.behaviorTask = behaviorTask;
+        this.target       = target;
+    }
+
+    /**
+     * Spawn the bot entity, equip it, and start its AI.
+     *
+     * @param plugin     owning plugin
+     * @param target     the player who will fight the bot
+     * @param location   where the bot should spawn (typically a few blocks
+     *                   in front of the player)
+     * @param kit        kit to equip on the bot (and optionally the player)
+     * @param kitApplier applier for kit contents
+     * @param settings   practice configuration
+     * @return the newly started session
+     */
+    public static BotSession spawn(Plugin plugin,
+            Player target,
+            Location location,
+            KitDefinition kit,
+            KitApplier kitApplier,
+            PracticeSettings settings) {
+
+        String botName = "§6PracticeBot";
+        World world = target.getWorld();
+
+        LivingEntity entity = BotPlayerFactory.spawn(plugin, world, location, botName, settings.botUseNms());
+        BotOpponent opponent = new BotOpponent(entity);
+        opponent.applyKit(kit, kitApplier);
+
+        BotBehaviorTask task = new BotBehaviorTask(plugin, opponent, target, settings);
+        task.start();
+
+        return new BotSession(opponent, task, target);
+    }
+
+    /**
+     * End the session and remove the bot.
+     *
+     * @param playerWon whether the player killed the bot (drives the summary message)
+     */
+    public void end(boolean playerWon) {
+        if (ended) return;
+        ended = true;
+        behaviorTask.stop();
+        opponent.remove();
+
+        if (target.isOnline()) {
+            Component title = playerWon
+                    ? Component.text("Bot Defeated!", NamedTextColor.GREEN, TextDecoration.BOLD)
+                    : Component.text("Practice Ended", NamedTextColor.GRAY, TextDecoration.BOLD);
+            Component subtitle = playerWon
+                    ? Component.text("Well done!", NamedTextColor.WHITE)
+                    : Component.text("Better luck next time.", NamedTextColor.GRAY);
+            target.showTitle(Title.title(title, subtitle,
+                    Title.Times.times(
+                            Duration.ofMillis(200),
+                            Duration.ofSeconds(3),
+                            Duration.ofMillis(500))));
+        }
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────
+
+    public BotOpponent opponent()       { return opponent; }
+    public boolean isEnded()            { return ended; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotSession.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/BotSession.java
@@ -80,16 +80,17 @@ public final class BotSession {
 
         if (target.isOnline()) {
             Component title = playerWon
-                    ? Component.text("Bot Defeated!", NamedTextColor.GREEN, TextDecoration.BOLD)
+                    ? Component.text("You Won!", NamedTextColor.GREEN, TextDecoration.BOLD)
                     : Component.text("Practice Ended", NamedTextColor.GRAY, TextDecoration.BOLD);
-            Component subtitle = playerWon
-                    ? Component.text("Well done!", NamedTextColor.WHITE)
-                    : Component.text("Better luck next time.", NamedTextColor.GRAY);
-            target.showTitle(Title.title(title, subtitle,
+            target.showTitle(Title.title(title, Component.empty(),
                     Title.Times.times(
                             Duration.ofMillis(200),
-                            Duration.ofSeconds(3),
-                            Duration.ofMillis(500))));
+                            Duration.ofSeconds(2),
+                            Duration.ofMillis(400))));
+            Component chatMsg = playerWon
+                    ? Component.text("§a§lBot Defeated! §7Well done — use §f/practice bot§7 to go again.")
+                    : Component.text("§e§lPractice Ended. §7Use §f/practice bot§7 to try again.");
+            target.sendMessage(chatMsg);
         }
     }
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/NmsSpawnHelper.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/NmsSpawnHelper.java
@@ -136,10 +136,28 @@ public final class NmsSpawnHelper {
                 for (Method m : nmsLevel.getClass().getMethods()) {
                     if ("removePlayerImmediately".equals(m.getName()) && m.getParameterCount() == 2) {
                         m.invoke(nmsLevel, entity, discarded);
-                        return;
+                        // Fall through to the WaypointManager safety net below — on Paper
+                        // 26.1.x the Moonrise EntityLookup may fail to remove the entity
+                        // from null chunk-slices and silently skip the onTrackingEnd
+                        // callback, leaving the fake bot registered as a waypoint
+                        // receiver.  The direct call below ensures cleanup even when
+                        // removePlayerImmediately's internal chain is interrupted.
+                        break;
                     }
                 }
             } catch (Exception ignored) {}
+        }
+
+        // Paper 26.1.x safety net: remove entity from ServerWaypointManager directly.
+        // When Moonrise's EntityLookup cannot find the entity in chunk slices (partial
+        // tracking failure after addFreshEntity), the EntityCallbacks.onTrackingEnd
+        // chain — which normally calls ServerWaypointManager.removePlayer — is never
+        // fired.  Without this explicit call the fake bot stays in the receiver map of
+        // every nearby waypoint and causes a NPE in
+        // WaypointTransmitter$EntityChunkConnection.disconnect() the next time a real
+        // player is teleported.
+        if (nmsLevel != null) {
+            tryDirectWaypointManagerRemove(nmsLevel, entity);
         }
 
         // Fallback: entity.setRemoved(DISCARDED)
@@ -156,5 +174,40 @@ public final class NmsSpawnHelper {
 
         // Last resort: entity.discard() (Paper convenience wrapper for setRemoved)
         try { entity.getClass().getMethod("discard").invoke(entity); } catch (Exception ignored) {}
+    }
+
+    /**
+     * Directly calls {@code ServerWaypointManager.removePlayer(entity)} by locating
+     * the manager field in the level's class hierarchy.
+     *
+     * <p>This is a targeted safety net for Paper 26.1.x.  On builds that do not have
+     * {@code ServerWaypointManager} (e.g. 1.21.x) the field scan silently finds
+     * nothing and returns without side effects.</p>
+     */
+    private static void tryDirectWaypointManagerRemove(Object nmsLevel, Object entity) {
+        try {
+            // Scan the level's class hierarchy for a field whose type is
+            // ServerWaypointManager (class name match is build-stable).
+            Object manager = null;
+            for (Class<?> c = nmsLevel.getClass(); c != null && manager == null;
+                    c = c.getSuperclass()) {
+                for (java.lang.reflect.Field f : c.getDeclaredFields()) {
+                    if ("ServerWaypointManager".equals(f.getType().getSimpleName())) {
+                        f.setAccessible(true);
+                        manager = f.get(nmsLevel);
+                        break;
+                    }
+                }
+            }
+            if (manager == null) return;
+
+            // ServerWaypointManager.removePlayer(ServerPlayer) — 1-param, any name
+            for (Method m : manager.getClass().getMethods()) {
+                if ("removePlayer".equals(m.getName()) && m.getParameterCount() == 1) {
+                    m.invoke(manager, entity);
+                    return;
+                }
+            }
+        } catch (Exception ignored) {}
     }
 }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/NmsSpawnHelper.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/bot/NmsSpawnHelper.java
@@ -1,0 +1,160 @@
+package com.pvpindex.battles.practice.bot;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * Static NMS reflection utilities shared by {@link BotNmsAdapter} implementations.
+ *
+ * <p>All methods are version-agnostic: they use only {@code java.lang.reflect} and
+ * never import NMS classes at compile time, so they work on Paper/Spigot 1.21.x
+ * and Paper 26.1.x without recompilation.</p>
+ *
+ * <p>This class is intentionally not exported as public API — it exists solely to
+ * eliminate duplication between {@code BotNmsAdapter121} and {@code BotNmsAdapter2610}.</p>
+ */
+public final class NmsSpawnHelper {
+
+    private NmsSpawnHelper() {}
+
+    // ── ClientInformation ─────────────────────────────────────────────────────
+
+    /**
+     * Locates and invokes {@code ClientInformation.createDefault()} across the class
+     * locations that differ between Paper 1.21.x and 26.1.x.
+     *
+     * @return the default {@code ClientInformation} instance, or {@code null} if none
+     *         of the candidate class paths exist on the current server
+     */
+    public static Object resolveClientInformationDefault() {
+        // Ordered by likelihood: 26.1.x path first, then 1.21.x fallbacks
+        String[] candidates = {
+            "net.minecraft.server.level.ClientInformation",
+            "net.minecraft.server.network.ClientInformation",
+            "net.minecraft.network.protocol.game.ClientboundLoginPacket$ClientInformation"
+        };
+        for (String className : candidates) {
+            try {
+                Class<?> cls = Class.forName(className);
+                Method m = cls.getDeclaredMethod("createDefault");
+                m.setAccessible(true);
+                Object result = m.invoke(null);
+                if (result != null) return result;
+            } catch (Exception ignored) {}
+        }
+        return null;
+    }
+
+    // ── ServerPlayer constructor ──────────────────────────────────────────────
+
+    /**
+     * Finds the {@code ServerPlayer} constructor that accepts four parameters:
+     * {@code (MinecraftServer, ServerLevel, GameProfile, ClientInformation)}.
+     *
+     * @param serverPlayerClass the resolved {@code net.minecraft.server.level.ServerPlayer} class
+     * @return the accessible constructor
+     * @throws NoSuchMethodException if no 4-parameter constructor exists
+     */
+    public static Constructor<?> resolveServerPlayerConstructor(Class<?> serverPlayerClass)
+            throws NoSuchMethodException {
+        for (Constructor<?> c : serverPlayerClass.getDeclaredConstructors()) {
+            if (c.getParameterCount() == 4) {
+                c.setAccessible(true);
+                return c;
+            }
+        }
+        throw new NoSuchMethodException("No 4-param constructor on ServerPlayer");
+    }
+
+    // ── ServerLevel.addFreshEntity ────────────────────────────────────────────
+
+    /**
+     * Reflectively calls {@code ServerLevel.addFreshEntity(Entity[, SpawnReason])}.
+     * Tries the 1-parameter overload first; falls back to the 2-parameter variant
+     * (Paper 1.21.4+ introduced an optional {@code SpawnReason} argument).
+     *
+     * @param nmsLevel the NMS {@code ServerLevel} object
+     * @param bot      the NMS {@code ServerPlayer} (or any {@code Entity}) to add
+     * @throws Exception if the method is not found or the invocation fails
+     */
+    public static void addFreshEntityReflective(Object nmsLevel, Object bot) throws Exception {
+        // 1-param: addFreshEntity(Entity) — most versions
+        for (Method m : nmsLevel.getClass().getMethods()) {
+            if ("addFreshEntity".equals(m.getName()) && m.getParameterCount() == 1) {
+                m.invoke(nmsLevel, bot);
+                return;
+            }
+        }
+        // 2-param: addFreshEntity(Entity, SpawnReason) — pass the first enum constant
+        for (Method m : nmsLevel.getClass().getMethods()) {
+            if ("addFreshEntity".equals(m.getName()) && m.getParameterCount() == 2) {
+                Object defaultReason = m.getParameterTypes()[1].getEnumConstants()[0];
+                m.invoke(nmsLevel, bot, defaultReason);
+                return;
+            }
+        }
+        throw new NoSuchMethodException(
+                "addFreshEntity not found on " + nmsLevel.getClass().getSimpleName());
+    }
+
+    // ── NMS entity cleanup ────────────────────────────────────────────────────
+
+    /**
+     * Best-effort NMS entity removal for a fake player whose spawn failed partway.
+     *
+     * <p>Calls {@code ServerLevel.removePlayerImmediately(entity, RemovalReason.DISCARDED)},
+     * which properly unregisters the entity from:</p>
+     * <ul>
+     *   <li>{@code ServerLevel} entity tracking / {@code EntityLookup}</li>
+     *   <li>{@code ServerWaypointManager} (Paper 26.1.x) — prevents the NPE in
+     *       {@code WaypointTransmitter$EntityChunkConnection.disconnect()} that fires
+     *       when a real player teleports and the waypoint manager iterates receivers</li>
+     *   <li>{@code PlayerList.players}</li>
+     * </ul>
+     *
+     * <p>Falls back to {@code entity.setRemoved(DISCARDED)}, then {@code entity.discard()}.
+     * All exceptions are swallowed — this is strictly best-effort cleanup.</p>
+     *
+     * @param nmsLevel the NMS {@code ServerLevel} the entity was (partially) added to;
+     *                 may be {@code null} if the level was never resolved
+     * @param entity   the NMS {@code Entity} / {@code ServerPlayer} to remove
+     */
+    public static void tryRemoveEntity(Object nmsLevel, Object entity) {
+        // Resolve RemovalReason.DISCARDED (inner enum — binary name uses '$')
+        Object discarded = null;
+        try {
+            Class<?> rrClass = Class.forName("net.minecraft.world.entity.Entity$RemovalReason");
+            for (Object c : rrClass.getEnumConstants()) {
+                if ("DISCARDED".equals(c.toString())) { discarded = c; break; }
+            }
+        } catch (Exception ignored) {}
+
+        // Preferred: ServerLevel.removePlayerImmediately(entity, DISCARDED)
+        // Mirrors what Paper calls during cross-world teleport; cleans up all tracking.
+        if (discarded != null && nmsLevel != null) {
+            try {
+                for (Method m : nmsLevel.getClass().getMethods()) {
+                    if ("removePlayerImmediately".equals(m.getName()) && m.getParameterCount() == 2) {
+                        m.invoke(nmsLevel, entity, discarded);
+                        return;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+
+        // Fallback: entity.setRemoved(DISCARDED)
+        if (discarded != null) {
+            try {
+                for (Method m : entity.getClass().getMethods()) {
+                    if ("setRemoved".equals(m.getName()) && m.getParameterCount() == 1) {
+                        m.invoke(entity, discarded);
+                        return;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+
+        // Last resort: entity.discard() (Paper convenience wrapper for setRemoved)
+        try { entity.getClass().getMethod("discard").invoke(entity); } catch (Exception ignored) {}
+    }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionScoreTracker.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionScoreTracker.java
@@ -1,0 +1,70 @@
+package com.pvpindex.battles.practice.reaction;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+/**
+ * Tracks per-session reaction-training statistics: hits, misses, combos,
+ * and reaction times (in milliseconds).  Pure data — no Bukkit dependency.
+ */
+public final class ReactionScoreTracker {
+
+    private int hits = 0;
+    private int misses = 0;
+    private int combo = 0;
+    private int bestCombo = 0;
+    private long bestTimeMs = Long.MAX_VALUE;
+    private final List<Long> reactionTimes = new ArrayList<>();
+
+    /** Register a successful hit with the given reaction time in ms. */
+    public void recordHit(long reactionTimeMs) {
+        hits++;
+        combo++;
+        if (combo > bestCombo) bestCombo = combo;
+        if (reactionTimeMs < bestTimeMs) bestTimeMs = reactionTimeMs;
+        reactionTimes.add(reactionTimeMs);
+    }
+
+    /** Register an expired target (miss). Resets the combo. */
+    public void recordMiss() {
+        misses++;
+        combo = 0;
+    }
+
+    /** Action-bar component shown while the drill is active. */
+    public Component formatActionBar() {
+        long best = bestTimeMs == Long.MAX_VALUE ? 0L : bestTimeMs;
+        return Component.text("⚡ ", NamedTextColor.YELLOW)
+                .append(Component.text("Hits: ", NamedTextColor.GRAY))
+                .append(Component.text(String.valueOf(hits), NamedTextColor.GREEN))
+                .append(Component.text("  Misses: ", NamedTextColor.GRAY))
+                .append(Component.text(String.valueOf(misses), NamedTextColor.RED))
+                .append(Component.text("  Combo: ", NamedTextColor.GRAY))
+                .append(Component.text("x" + combo, combo >= 5 ? NamedTextColor.GOLD : NamedTextColor.WHITE))
+                .append(Component.text("  Best: ", NamedTextColor.GRAY))
+                .append(Component.text(best + "ms", NamedTextColor.AQUA));
+    }
+
+    /** Full summary title component shown at the end of the session. */
+    public Component formatSummary() {
+        long avg = reactionTimes.isEmpty() ? 0L
+                : (long) reactionTimes.stream().mapToLong(Long::longValue).average().orElse(0);
+        long best = bestTimeMs == Long.MAX_VALUE ? 0L : bestTimeMs;
+        return Component.text("Practice Summary", NamedTextColor.GOLD, TextDecoration.BOLD)
+                .append(Component.newline())
+                .append(Component.text("Hits: " + hits + "  Misses: " + misses, NamedTextColor.WHITE))
+                .append(Component.newline())
+                .append(Component.text("Best: " + best + "ms  Avg: " + avg + "ms", NamedTextColor.AQUA))
+                .append(Component.newline())
+                .append(Component.text("Best Combo: ×" + bestCombo, NamedTextColor.GOLD));
+    }
+
+    public int hits()         { return hits; }
+    public int misses()       { return misses; }
+    public int combo()        { return combo; }
+    public int bestCombo()    { return bestCombo; }
+    public long bestTimeMs()  { return bestTimeMs; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionScoreTracker.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionScoreTracker.java
@@ -5,7 +5,6 @@ import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-
 /**
  * Tracks per-session reaction-training statistics: hits, misses, combos,
  * and reaction times (in milliseconds).  Pure data — no Bukkit dependency.
@@ -60,6 +59,28 @@ public final class ReactionScoreTracker {
                 .append(Component.text("Best: " + best + "ms  Avg: " + avg + "ms", NamedTextColor.AQUA))
                 .append(Component.newline())
                 .append(Component.text("Best Combo: ×" + bestCombo, NamedTextColor.GOLD));
+    }
+
+    /** Chat-friendly summary: each element is one line to send via {@code player.sendMessage()}. */
+    public List<Component> chatSummaryLines() {
+        long avg = reactionTimes.isEmpty() ? 0L
+                : (long) reactionTimes.stream().mapToLong(Long::longValue).average().orElse(0);
+        long best = bestTimeMs == Long.MAX_VALUE ? 0L : bestTimeMs;
+        return List.of(
+                Component.text("─── ", NamedTextColor.DARK_GRAY)
+                        .append(Component.text("Reaction Training Results", NamedTextColor.GOLD, TextDecoration.BOLD))
+                        .append(Component.text(" ───", NamedTextColor.DARK_GRAY)),
+                Component.text("  Hits: ", NamedTextColor.GRAY)
+                        .append(Component.text(String.valueOf(hits), NamedTextColor.GREEN))
+                        .append(Component.text("  Misses: ", NamedTextColor.GRAY))
+                        .append(Component.text(String.valueOf(misses), NamedTextColor.RED)),
+                Component.text("  Best: ", NamedTextColor.GRAY)
+                        .append(Component.text(best + "ms", NamedTextColor.AQUA))
+                        .append(Component.text("  Avg: ", NamedTextColor.GRAY))
+                        .append(Component.text(avg + "ms", NamedTextColor.AQUA)),
+                Component.text("  Best Combo: ", NamedTextColor.GRAY)
+                        .append(Component.text("×" + bestCombo, NamedTextColor.GOLD))
+        );
     }
 
     public int hits()         { return hits; }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTarget.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTarget.java
@@ -1,0 +1,174 @@
+package com.pvpindex.battles.practice.reaction;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * A single hittable reaction-training target.
+ *
+ * <p>Visually, each target is a small invisible {@link ArmorStand} surrounded
+ * by layered particle effects:</p>
+ * <ul>
+ *   <li>Continuous white {@code END_ROD} glow</li>
+ *   <li>Rotating cyan {@code WAX_ON} halo ring (8-point, sin/cos)</li>
+ *   <li>Pulsing aqua {@code FIREWORK} core</li>
+ * </ul>
+ *
+ * <p>When a player sword-hits the ArmorStand, {@link #remove(boolean)} is called
+ * with {@code burst=true}, spawning an explosion + confetti particle burst and
+ * playing a satisfying sound combination.</p>
+ */
+public final class ReactionTarget {
+
+    /** PDC key placed on every reaction-target ArmorStand. */
+    public static final NamespacedKey PDC_KEY = new NamespacedKey("pvpindex", "reaction_target");
+
+    private final ArmorStand stand;
+    private final long spawnTimeMs;
+
+    // Either Folia ScheduledTask or legacy BukkitTask – only one will be non-null.
+    private ScheduledTask foliaTask;
+    private BukkitTask bukkitTask;
+
+    private volatile boolean removed = false;
+
+    /**
+     * Spawns the ArmorStand at {@code location} and immediately starts the
+     * particle animation.
+     */
+    public ReactionTarget(Plugin plugin, Location location) {
+        this.spawnTimeMs = System.currentTimeMillis();
+
+        ArmorStand as = (ArmorStand) location.getWorld().spawnEntity(location, EntityType.ARMOR_STAND);
+        as.setInvisible(true);
+        as.setSmall(true);
+        as.setGravity(false);
+        as.setInvulnerable(false);
+        as.setArms(false);
+        as.setBasePlate(false);
+        as.setCustomNameVisible(false);
+        as.getPersistentDataContainer().set(PDC_KEY, PersistentDataType.BYTE, (byte) 1);
+        this.stand = as;
+
+        startAnimation(plugin);
+    }
+
+    // ── Animation ────────────────────────────────────────────────────────────
+
+    private void startAnimation(Plugin plugin) {
+        AtomicInteger tick = new AtomicInteger(0);
+        try {
+            // Folia / Paper-Folia entity scheduler
+            foliaTask = stand.getScheduler().runAtFixedRate(
+                    plugin,
+                    task -> {
+                        if (removed || !stand.isValid()) {
+                            task.cancel();
+                            return;
+                        }
+                        animateTick(tick.getAndIncrement());
+                    },
+                    null, // retired callback
+                    1L,   // initial delay
+                    2L    // period
+            );
+        } catch (UnsupportedOperationException | NoSuchMethodError e) {
+            // Legacy Paper without Folia API stubs
+            bukkitTask = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+                if (removed || !stand.isValid()) {
+                    if (bukkitTask != null) bukkitTask.cancel();
+                    return;
+                }
+                animateTick(tick.getAndIncrement());
+            }, 0L, 2L);
+        }
+    }
+
+    private void animateTick(int tick) {
+        if (!stand.isValid()) return;
+        World world = stand.getWorld();
+        Location center = stand.getLocation().add(0, 0.9, 0); // chest height
+
+        // ─ Continuous white END_ROD glow ─────────────────────────────────
+        world.spawnParticle(Particle.END_ROD, center, 3, 0.12, 0.12, 0.12, 0.008);
+
+        // ─ Rotating 8-point WAX_ON halo ring (every 4 ticks) ─────────────
+        if (tick % 4 == 0) {
+            double angleMod = tick * 0.18; // slow rotation
+            for (int i = 0; i < 8; i++) {
+                double angle = (Math.PI * 2 / 8) * i + angleMod;
+                double rx = Math.cos(angle) * 0.55;
+                double rz = Math.sin(angle) * 0.55;
+                world.spawnParticle(Particle.WAX_ON, center.clone().add(rx, 0, rz),
+                        1, 0, 0, 0, 0);
+            }
+        }
+
+        // ─ Pulsing FIREWORK core (every 6 ticks) ─────────────────────────
+        if (tick % 6 == 0) {
+            world.spawnParticle(Particle.FIREWORK, center, 2, 0.06, 0.06, 0.06, 0.015);
+        }
+
+        // ─ Subtle vertical DUST sweep (every 10 ticks) ────────────────────
+        if (tick % 10 == 0) {
+            var dustOptions = new Particle.DustOptions(org.bukkit.Color.fromRGB(0, 200, 255), 0.8f);
+            world.spawnParticle(Particle.DUST, center, 4, 0.2, 0.3, 0.2, 0, dustOptions);
+        }
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    /**
+     * Removes this target. When {@code burst} is {@code true} a confetti
+     * particle explosion and hit sounds are played before despawning.
+     */
+    public void remove(boolean burst) {
+        if (removed) return;
+        removed = true;
+        cancelAnimationTask();
+        if (stand.isValid()) {
+            if (burst) {
+                spawnHitBurst();
+            }
+            stand.remove();
+        }
+    }
+
+    private void cancelAnimationTask() {
+        if (foliaTask != null)   foliaTask.cancel();
+        if (bukkitTask != null)  bukkitTask.cancel();
+    }
+
+    private void spawnHitBurst() {
+        Location loc = stand.getLocation().add(0, 0.9, 0);
+        World world = stand.getWorld();
+        world.spawnParticle(Particle.EXPLOSION_EMITTER, loc, 1);
+        world.spawnParticle(Particle.FIREWORK, loc, 25, 0.45, 0.45, 0.45, 0.1);
+        world.spawnParticle(Particle.END_ROD,  loc, 14, 0.3,  0.3,  0.3,  0.07);
+        var lime = new Particle.DustOptions(org.bukkit.Color.fromRGB(0, 255, 80), 1.2f);
+        world.spawnParticle(Particle.DUST, loc, 10, 0.3, 0.3, 0.3, 0, lime);
+        world.playSound(loc, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 2.0f);
+        world.playSound(loc, Sound.BLOCK_NOTE_BLOCK_PLING,        0.8f, 2.0f);
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────
+
+    /** Milliseconds elapsed since this target was spawned. */
+    public long reactionTimeMs() {
+        return System.currentTimeMillis() - spawnTimeMs;
+    }
+
+    public ArmorStand stand()   { return stand; }
+    public boolean isRemoved()  { return removed; }
+    public long spawnTimeMs()   { return spawnTimeMs; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTarget.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTarget.java
@@ -16,25 +16,33 @@ import org.bukkit.scheduler.BukkitTask;
 /**
  * A single hittable reaction-training target.
  *
- * <p>Visually, each target is a small invisible {@link ArmorStand} surrounded
+ * <p>Visually each target is a small invisible {@link ArmorStand} surrounded
  * by layered particle effects:</p>
  * <ul>
- *   <li>Continuous white {@code END_ROD} glow</li>
- *   <li>Rotating cyan {@code WAX_ON} halo ring (8-point, sin/cos)</li>
- *   <li>Pulsing aqua {@code FIREWORK} core</li>
+ *   <li>Countdown ring — up to {@value #MAX_STARS} fixed END_ROD stars that
+ *       disappear one-by-one as the target ages, giving a clear remaining-time
+ *       indicator.</li>
+ *   <li>Hitbox ring — six DUST dots at the click radius (≈ 0.35 blocks) that
+ *       shift from cyan → orange → red as the target approaches expiry.</li>
+ *   <li>Core glow — a tight GLOW / END_ROD cluster at the exact centre so
+ *       the player always knows where to aim.</li>
  * </ul>
  *
- * <p>When a player sword-hits the ArmorStand, {@link #remove(boolean)} is called
- * with {@code burst=true}, spawning an explosion + confetti particle burst and
- * playing a satisfying sound combination.</p>
+ * <p>When hit, {@link #remove(boolean)} with {@code burst=true} spawns a
+ * confetti explosion and plays a satisfying sound combination.</p>
  */
 public final class ReactionTarget {
 
     /** PDC key placed on every reaction-target ArmorStand. */
     public static final NamespacedKey PDC_KEY = new NamespacedKey("pvpindex", "reaction_target");
 
+    /** Number of countdown stars shown at full lifetime. */
+    private static final int MAX_STARS = 8;
+
     private final ArmorStand stand;
     private final long spawnTimeMs;
+    /** Total lifetime in milliseconds — used to compute the age ratio. */
+    private final long lifetimeMs;
 
     // Either Folia ScheduledTask or legacy BukkitTask – only one will be non-null.
     private ScheduledTask foliaTask;
@@ -45,9 +53,12 @@ public final class ReactionTarget {
     /**
      * Spawns the ArmorStand at {@code location} and immediately starts the
      * particle animation.
+     *
+     * @param lifetimeMs total lifetime in milliseconds; drives the countdown ring
      */
-    public ReactionTarget(Plugin plugin, Location location) {
+    public ReactionTarget(Plugin plugin, Location location, long lifetimeMs) {
         this.spawnTimeMs = System.currentTimeMillis();
+        this.lifetimeMs  = lifetimeMs;
 
         ArmorStand as = (ArmorStand) location.getWorld().spawnEntity(location, EntityType.ARMOR_STAND);
         as.setInvisible(true);
@@ -99,30 +110,51 @@ public final class ReactionTarget {
         World world = stand.getWorld();
         Location center = stand.getLocation().add(0, 0.9, 0); // chest height
 
-        // ─ Continuous white END_ROD glow ─────────────────────────────────
-        world.spawnParticle(Particle.END_ROD, center, 3, 0.12, 0.12, 0.12, 0.008);
+        // Age ratio: 0.0 = just spawned, 1.0 = lifetime exhausted
+        double ageRatio  = lifetimeMs > 0
+                ? Math.min(1.0, (double) (System.currentTimeMillis() - spawnTimeMs) / lifetimeMs)
+                : 0.0;
+        double remaining = 1.0 - ageRatio;
 
-        // ─ Rotating 8-point WAX_ON halo ring (every 4 ticks) ─────────────
-        if (tick % 4 == 0) {
-            double angleMod = tick * 0.18; // slow rotation
-            for (int i = 0; i < 8; i++) {
-                double angle = (Math.PI * 2 / 8) * i + angleMod;
-                double rx = Math.cos(angle) * 0.55;
-                double rz = Math.sin(angle) * 0.55;
-                world.spawnParticle(Particle.WAX_ON, center.clone().add(rx, 0, rz),
+        // ─ Countdown ring: fixed END_ROD stars, disappearing one-by-one ──────
+        // Stars sit at fixed angular positions so the player can watch them vanish.
+        if (tick % 3 == 0) {
+            int litStars = (int) Math.ceil(remaining * MAX_STARS);
+            for (int i = 0; i < litStars; i++) {
+                double angle = (Math.PI * 2.0 / MAX_STARS) * i;
+                world.spawnParticle(Particle.END_ROD,
+                        center.clone().add(Math.cos(angle) * 0.65, 0, Math.sin(angle) * 0.65),
                         1, 0, 0, 0, 0);
             }
         }
 
-        // ─ Pulsing FIREWORK core (every 6 ticks) ─────────────────────────
-        if (tick % 6 == 0) {
-            world.spawnParticle(Particle.FIREWORK, center, 2, 0.06, 0.06, 0.06, 0.015);
+        // ─ Core glow: bright cluster at the exact click point ────────────────
+        if (tick % 4 == 0) {
+            world.spawnParticle(Particle.GLOW, center, 3, 0.05, 0.05, 0.05, 0);
         }
 
-        // ─ Subtle vertical DUST sweep (every 10 ticks) ────────────────────
-        if (tick % 10 == 0) {
-            var dustOptions = new Particle.DustOptions(org.bukkit.Color.fromRGB(0, 200, 255), 0.8f);
-            world.spawnParticle(Particle.DUST, center, 4, 0.2, 0.3, 0.2, 0, dustOptions);
+        // ─ Hitbox ring: DUST dots at click radius, colour = time remaining ───
+        // Cyan (fresh) → orange (half-way) → red (about to expire).
+        if (tick % 6 == 0) {
+            org.bukkit.Color ringColor;
+            if (remaining > 0.6) {
+                ringColor = org.bukkit.Color.fromRGB(0, 200, 255);   // cyan
+            } else if (remaining > 0.3) {
+                ringColor = org.bukkit.Color.fromRGB(255, 140, 0);   // orange
+            } else {
+                ringColor = org.bukkit.Color.fromRGB(255, 40, 40);   // red
+            }
+            var dust = new Particle.DustOptions(ringColor, 0.9f);
+            // Equatorial ring
+            for (int i = 0; i < 6; i++) {
+                double angle = (Math.PI * 2.0 / 6) * i;
+                world.spawnParticle(Particle.DUST,
+                        center.clone().add(Math.cos(angle) * 0.35, 0, Math.sin(angle) * 0.35),
+                        1, 0, 0, 0, 0, dust);
+            }
+            // Top and bottom caps for 3-D depth cue
+            world.spawnParticle(Particle.DUST, center.clone().add(0,  0.35, 0), 1, 0, 0, 0, 0, dust);
+            world.spawnParticle(Particle.DUST, center.clone().add(0, -0.35, 0), 1, 0, 0, 0, 0, dust);
         }
     }
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
@@ -2,10 +2,14 @@ package com.pvpindex.battles.practice.reaction;
 
 import com.pvpindex.battles.practice.PracticeSession;
 import com.pvpindex.battles.practice.PracticeSettings;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -98,13 +102,18 @@ public final class ReactionTrainer {
         activeTargets.clear();
         if (player != null && player.isOnline()) {
             player.clearTitle();
+            // Short title notification
             player.showTitle(Title.title(
-                    score.formatSummary(),
-                    net.kyori.adventure.text.Component.empty(),
+                    Component.text("Session Over!", NamedTextColor.GOLD, TextDecoration.BOLD),
+                    Component.text("Results in chat ↓", NamedTextColor.GRAY),
                     Title.Times.times(
-                            java.time.Duration.ofMillis(200),
-                            java.time.Duration.ofSeconds(5),
-                            java.time.Duration.ofMillis(500))));
+                            Duration.ofMillis(200),
+                            Duration.ofSeconds(2),
+                            Duration.ofMillis(400))));
+            // Detailed results sent to chat
+            for (Component line : score.chatSummaryLines()) {
+                player.sendMessage(line);
+            }
         }
     }
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
@@ -39,6 +39,12 @@ public final class ReactionTrainer {
     // Session data
     private Player player;
     private PracticeSession session;
+    /**
+     * Arena floor centre used when {@code spawn_mode = "arena"}.
+     * {@code null} until set by {@link #setArenaCenter(Location)}, which causes
+     * the trainer to fall back to player-relative spawning.
+     */
+    private Location arenaCenter = null;
 
     // Scheduler tasks
     private BukkitTask spawnTask;
@@ -138,23 +144,44 @@ public final class ReactionTrainer {
 
     private void spawnTarget() {
         if (!player.isOnline()) return;
+        long lifetimeMs = (long) settings.reactionTargetLifetimeTicks() * 50L;
+        if (arenaCenter != null && "arena".equals(settings.reactionSpawnMode())) {
+            spawnTargetArenaRelative(lifetimeMs);
+        } else {
+            spawnTargetPlayerRelative(lifetimeMs);
+        }
+    }
+
+    /** Spawns a target at a random position relative to the arena floor centre. */
+    private void spawnTargetArenaRelative(long lifetimeMs) {
+        double radius      = settings.reactionArenaSpawnRadius();
+        double heightRange = settings.reactionArenaHeightRange();
+        double angle    = random.nextDouble() * Math.PI * 2;
+        double distance = 1.5 + random.nextDouble() * Math.max(0, radius - 1.5);
+        Location spawnLoc = arenaCenter.clone().add(
+                Math.cos(angle) * distance,
+                0.7 + random.nextDouble() * heightRange,
+                Math.sin(angle) * distance);
+        activeTargets.add(new ReactionTarget(plugin, spawnLoc, lifetimeMs));
+    }
+
+    /** Original player-relative spawn (opt-in via {@code spawn_mode: player}). */
+    private void spawnTargetPlayerRelative(long lifetimeMs) {
         Location eye = player.getEyeLocation();
-
-        // Random horizontal offset within a hemisphere in front of the player
-        double angle = random.nextDouble() * Math.PI * 2;
+        double angle    = random.nextDouble() * Math.PI * 2;
         double distance = 2.5 + random.nextDouble() * SPREAD_H;
-        double offsetX = Math.cos(angle) * distance;
-        double offsetZ = Math.sin(angle) * distance;
-        double offsetY = (random.nextDouble() - 0.5) * SPREAD_V * 2;
-
+        double offsetX  = Math.cos(angle) * distance;
+        double offsetZ  = Math.sin(angle) * distance;
+        double offsetY  = (random.nextDouble() - 0.5) * SPREAD_V * 2;
         Location spawnLoc = eye.clone().add(offsetX, offsetY - 0.9, offsetZ);
-        // Keep Y above ground
         spawnLoc.setY(Math.max(spawnLoc.getY(), eye.getY() - 1.2));
-
-        activeTargets.add(new ReactionTarget(plugin, spawnLoc));
+        activeTargets.add(new ReactionTarget(plugin, spawnLoc, lifetimeMs));
     }
 
     // ── Accessors ─────────────────────────────────────────────────────────
+
+    /** Sets the arena floor centre for arena-relative target spawning. */
+    public void setArenaCenter(Location center) { this.arenaCenter = center; }
 
     public boolean isRunning()                      { return running; }
     public ReactionScoreTracker score()             { return score; }

--- a/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/practice/reaction/ReactionTrainer.java
@@ -1,0 +1,154 @@
+package com.pvpindex.battles.practice.reaction;
+
+import com.pvpindex.battles.practice.PracticeSession;
+import com.pvpindex.battles.practice.PracticeSettings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Orchestrates a reaction-training session for one player.
+ *
+ * <p>Targets are spawned at a configurable interval (default 40 ticks / 2 s)
+ * at random offsets around the player's current eye position.  Targets that
+ * are not hit within their lifetime are counted as misses and removed silently.
+ * The player's score is displayed live on the action bar after every event.</p>
+ */
+public final class ReactionTrainer {
+
+    /** Maximum angular offset (in blocks) when randomly positioning a target. */
+    private static final double SPREAD_H = 4.5;
+    private static final double SPREAD_V = 1.2;
+
+    private final Plugin plugin;
+    private final PracticeSettings settings;
+    private final ReactionScoreTracker score = new ReactionScoreTracker();
+    private final List<ReactionTarget> activeTargets = new ArrayList<>();
+    private final Random random = new Random();
+
+    // Session data
+    private Player player;
+    private PracticeSession session;
+
+    // Scheduler tasks
+    private BukkitTask spawnTask;
+    private BukkitTask expireTask;
+
+    private boolean running = false;
+
+    public ReactionTrainer(Plugin plugin, PracticeSettings settings) {
+        this.plugin = plugin;
+        this.settings = settings;
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    /** Begin a new training session for the given player. */
+    public void start(Player player, PracticeSession session) {
+        if (running) stop();
+        this.player = player;
+        this.session = session;
+        this.running = true;
+
+        // Target-spawn loop
+        spawnTask = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+            if (!player.isOnline() || !running) {
+                stop();
+                return;
+            }
+            if (activeTargets.size() < settings.reactionMaxTargets()) {
+                spawnTarget();
+            }
+        }, settings.reactionSpawnIntervalTicks(), settings.reactionSpawnIntervalTicks());
+
+        // Expiry-check loop (runs every 10 ticks to avoid tick-perfect timing issues)
+        expireTask = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+            if (!running) return;
+            long now = System.currentTimeMillis();
+            long lifetimeMs = settings.reactionTargetLifetimeTicks() * 50L;
+            List<ReactionTarget> expired = activeTargets.stream()
+                    .filter(t -> !t.isRemoved() && (now - t.spawnTimeMs()) >= lifetimeMs)
+                    .toList();
+            for (ReactionTarget t : expired) {
+                t.remove(false); // silent — no burst for a miss
+                activeTargets.remove(t);
+                score.recordMiss();
+            }
+            if (player.isOnline()) {
+                player.sendActionBar(score.formatActionBar());
+            }
+        }, 10L, 10L);
+    }
+
+    /** Stop the session, remove all remaining targets, and show the summary. */
+    public void stop() {
+        if (!running) return;
+        running = false;
+        if (spawnTask  != null) spawnTask.cancel();
+        if (expireTask != null) expireTask.cancel();
+        for (ReactionTarget t : List.copyOf(activeTargets)) {
+            t.remove(false);
+        }
+        activeTargets.clear();
+        if (player != null && player.isOnline()) {
+            player.clearTitle();
+            player.showTitle(Title.title(
+                    score.formatSummary(),
+                    net.kyori.adventure.text.Component.empty(),
+                    Title.Times.times(
+                            java.time.Duration.ofMillis(200),
+                            java.time.Duration.ofSeconds(5),
+                            java.time.Duration.ofMillis(500))));
+        }
+    }
+
+    /**
+     * Called by {@link com.pvpindex.battles.listener.PracticeListener} when the
+     * player successfully lands a sword hit on a reaction target.
+     *
+     * @param target the target that was hit
+     */
+    public void onTargetHit(ReactionTarget target) {
+        if (!running || target.isRemoved()) return;
+        long reactionMs = target.reactionTimeMs();
+        target.remove(true); // burst!
+        activeTargets.remove(target);
+        score.recordHit(reactionMs);
+        if (player != null && player.isOnline()) {
+            player.sendActionBar(score.formatActionBar());
+        }
+    }
+
+    // ── Target spawning ───────────────────────────────────────────────────
+
+    private void spawnTarget() {
+        if (!player.isOnline()) return;
+        Location eye = player.getEyeLocation();
+
+        // Random horizontal offset within a hemisphere in front of the player
+        double angle = random.nextDouble() * Math.PI * 2;
+        double distance = 2.5 + random.nextDouble() * SPREAD_H;
+        double offsetX = Math.cos(angle) * distance;
+        double offsetZ = Math.sin(angle) * distance;
+        double offsetY = (random.nextDouble() - 0.5) * SPREAD_V * 2;
+
+        Location spawnLoc = eye.clone().add(offsetX, offsetY - 0.9, offsetZ);
+        // Keep Y above ground
+        spawnLoc.setY(Math.max(spawnLoc.getY(), eye.getY() - 1.2));
+
+        activeTargets.add(new ReactionTarget(plugin, spawnLoc));
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────
+
+    public boolean isRunning()                      { return running; }
+    public ReactionScoreTracker score()             { return score; }
+    public List<ReactionTarget> activeTargets()     { return List.copyOf(activeTargets); }
+    public UUID playerUuid()                        { return player != null ? player.getUniqueId() : null; }
+}

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ArenaPoolService.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ArenaPoolService.java
@@ -64,9 +64,14 @@ public final class ArenaPoolService {
     /** Prefill {@code warmSize} instances per known template, asynchronously. */
     public void warmAll(int warmSize) {
         configure(warmSize, this.refillAsync);
+        // Stagger each warm-up task by 2 ticks (≈100 ms) so that multiple
+        // world-creation calls are spread across separate server ticks instead
+        // of all firing on the first tick after onEnable.
+        int delay = 1;
         for (String templateId : generator.templateIds()) {
             for (int i = 0; i < warmSize; i++) {
-                generateAsync(templateId);
+                generateAsync(templateId, delay);
+                delay += 2;
             }
         }
     }
@@ -139,7 +144,12 @@ public final class ArenaPoolService {
         }
     }
 
+    /** Overload used by {@link #release} and the cold-pool path in {@link #acquire} — no startup delay. */
     private void generateAsync(String templateId) {
+        generateAsync(templateId, 0);
+    }
+
+    private void generateAsync(String templateId, int delayTicks) {
         if (brokenTemplates.contains(templateId)) return;
         Runnable task = () -> {
             try {
@@ -171,13 +181,25 @@ public final class ArenaPoolService {
             Optional<ArenaTemplate> tpl = generator.findTemplate(templateId);
             boolean isCopy = tpl.map(t -> "copy".equalsIgnoreCase(t.strategy())).orElse(false);
             if (isCopy) {
-                Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+                if (delayTicks > 0) {
+                    Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task, delayTicks);
+                } else {
+                    Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+                }
             } else {
                 // Folia does not support sync global tasks; fall back to GlobalRegionScheduler.
                 try {
-                    Bukkit.getScheduler().runTask(plugin, task);
+                    if (delayTicks > 0) {
+                        Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+                    } else {
+                        Bukkit.getScheduler().runTask(plugin, task);
+                    }
                 } catch (UnsupportedOperationException e) {
-                    plugin.getServer().getGlobalRegionScheduler().run(plugin, ignored -> task.run());
+                    if (delayTicks > 0) {
+                        plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, ignored -> task.run(), delayTicks);
+                    } else {
+                        plugin.getServer().getGlobalRegionScheduler().run(plugin, ignored -> task.run());
+                    }
                 }
             }
         } else {

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralArenaStrategy.java
@@ -89,6 +89,19 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
         // already fully built when createWorld() returns. Only game rules remain.
         configureWorld(world);
 
+        // Pre-load every chunk the arena footprint touches. On Paper, spawn-area
+        // chunks are already generated during createWorld(). On Spigot and other
+        // Bukkit implementations only the chunk at the world spawn may be ready —
+        // explicitly calling getChunkAt() triggers generateSurface() for any
+        // remaining chunks, guaranteeing the arena is fully built on all server types.
+        int minC = Math.floorDiv(-RADIUS, 16);
+        int maxC = Math.floorDiv( RADIUS, 16);
+        for (int cx = minC; cx <= maxC; cx++) {
+            for (int cz = minC; cz <= maxC; cz++) {
+                world.getChunkAt(cx, cz);
+            }
+        }
+
         plugin.getLogger().info("Built procedural arena " + worldName + " from template " + template.id());
         return new ArenaInstance(id, template.id(), world.getName(),
                 spawnsFor(template), template.spectatorSpawn());
@@ -188,6 +201,12 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
         world.setTime(6000L); // noon
         world.setStorm(false);
         world.setThundering(false);
+        // Constrain the world border to just outside the arena so the server never
+        // generates chunks beyond the arena footprint. Works on all Bukkit implementations.
+        // setWarningDistance(0) suppresses the red vignette inside the arena walls.
+        world.getWorldBorder().setCenter(0, 0);
+        world.getWorldBorder().setSize(RADIUS * 2 + 1 + 48.0);
+        world.getWorldBorder().setWarningDistance(0);
     }
 
     @SuppressWarnings("unchecked")

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralArenaStrategy.java
@@ -3,16 +3,21 @@ package com.pvpindex.battles.world;
 import com.pvpindex.battles.arena.SpawnPoint;
 import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.GameRule;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
-import org.bukkit.block.Block;
+import org.bukkit.generator.BlockPopulator;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.WorldInfo;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Builds a small symmetrical PvP arena in a fresh void world, in code, with
@@ -72,7 +77,7 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
         // even when a custom ChunkGenerator is supplied, producing a harmless
         // but noisy "No key layers in MapLike[{}]" error on every world create.
         WorldCreator creator = new WorldCreator(worldName)
-                .generator(new VoidWorldGenerator())
+                .generator(new ArenaChunkGenerator())
                 .type(WorldType.NORMAL)
                 .generateStructures(false);
         World world = Bukkit.createWorld(creator);
@@ -80,8 +85,9 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
             throw new IOException("Failed to create arena world: " + worldName);
         }
 
+        // Arena structure is embedded in the ChunkGenerator — spawn chunks are
+        // already fully built when createWorld() returns. Only game rules remain.
         configureWorld(world);
-        buildArena(world);
 
         plugin.getLogger().info("Built procedural arena " + worldName + " from template " + template.id());
         return new ArenaInstance(id, template.id(), world.getName(),
@@ -92,6 +98,73 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
     public void release(ArenaInstance instance) {
         // Pool service handles unload+delete via the generic pvpindex_* path
         // (see ArenaPoolService.unloadAndDelete). Nothing else to do here.
+    }
+
+    // -------------------------------------------------------------------------
+    // Chunk generator — embeds the full arena structure during world creation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Custom {@link ChunkGenerator} that places the duel arena's floor and walls
+     * in {@code generateSurface()} so the structure is ready the moment
+     * {@link Bukkit#createWorld(WorldCreator)} returns — no separate block-loop
+     * pass needed. All other terrain passes are suppressed (void world).
+     */
+    private static final class ArenaChunkGenerator extends ChunkGenerator {
+
+        @Override
+        public void generateSurface(@NotNull WorldInfo worldInfo, @NotNull Random random,
+                                    int chunkX, int chunkZ, @NotNull ChunkData chunkData) {
+            // Clip the arena footprint to this chunk's block range.
+            int blockMinX = chunkX * 16;
+            int blockMinZ = chunkZ * 16;
+            int startX = Math.max(-RADIUS, blockMinX);
+            int endX   = Math.min( RADIUS, blockMinX + 15);
+            int startZ = Math.max(-RADIUS, blockMinZ);
+            int endZ   = Math.min( RADIUS, blockMinZ + 15);
+            if (startX > endX || startZ > endZ) return;
+
+            for (int wx = startX; wx <= endX; wx++) {
+                int lx = wx - blockMinX;
+                for (int wz = startZ; wz <= endZ; wz++) {
+                    int lz = wz - blockMinZ;
+                    boolean perimeter = (wx == -RADIUS || wx == RADIUS || wz == -RADIUS || wz == RADIUS);
+                    boolean spawnPad  = isSpawnPad(wx, wz);
+                    // Floor
+                    chunkData.setBlock(lx, FLOOR_Y, lz,
+                            spawnPad ? Material.IRON_BLOCK : Material.STONE_BRICKS);
+                    // Perimeter wall: 1 stone-brick base + glass courses above
+                    if (perimeter) {
+                        chunkData.setBlock(lx, FLOOR_Y + 1, lz, Material.STONE_BRICKS);
+                        for (int dy = 2; dy <= WALL_HEIGHT; dy++) {
+                            chunkData.setBlock(lx, FLOOR_Y + dy, lz, Material.GLASS);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static boolean isSpawnPad(int x, int z) {
+            if (z < -1 || z > 1) return false;
+            return (x >= -RADIUS && x <= -RADIUS + 2) || (x >= RADIUS - 2 && x <= RADIUS);
+        }
+
+        @Override public boolean shouldGenerateNoise()       { return false; }
+        @Override public boolean shouldGenerateSurface()     { return false; }
+        @Override public boolean shouldGenerateCaves()       { return false; }
+        @Override public boolean shouldGenerateDecorations() { return false; }
+        @Override public boolean shouldGenerateMobs()        { return false; }
+        @Override public boolean shouldGenerateStructures()  { return false; }
+
+        @Override
+        public @NotNull Location getFixedSpawnLocation(@NotNull World world, @NotNull Random random) {
+            return new Location(world, 0, FLOOR_Y + 1, 0);
+        }
+
+        @Override
+        public @NotNull List<BlockPopulator> getDefaultPopulators(@NotNull World world) {
+            return List.of();
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -123,38 +196,6 @@ public final class ProceduralArenaStrategy implements WorldGenerationStrategy {
         if (rule != null) world.setGameRule(rule, value);
     }
 
-    private void buildArena(World world) {
-        // Floor — 21x21 stone bricks, with iron spawn pads at the ends.
-        for (int x = -RADIUS; x <= RADIUS; x++) {
-            for (int z = -RADIUS; z <= RADIUS; z++) {
-                Block b = world.getBlockAt(x, FLOOR_Y, z);
-                Material mat = isSpawnPad(x, z) ? Material.IRON_BLOCK : Material.STONE_BRICKS;
-                b.setType(mat, false);
-            }
-        }
-        // Perimeter wall — 1 stone-brick base + 4 glass courses above.
-        for (int x = -RADIUS; x <= RADIUS; x++) {
-            placeWall(world, x, -RADIUS);
-            placeWall(world, x,  RADIUS);
-        }
-        for (int z = -RADIUS + 1; z <= RADIUS - 1; z++) {
-            placeWall(world, -RADIUS, z);
-            placeWall(world,  RADIUS, z);
-        }
-    }
-
-    private void placeWall(World world, int x, int z) {
-        for (int dy = 1; dy <= WALL_HEIGHT; dy++) {
-            Material mat = (dy == 1) ? Material.STONE_BRICKS : Material.GLASS;
-            world.getBlockAt(x, FLOOR_Y + dy, z).setType(mat, false);
-        }
-    }
-
-    /** West and east 3x3 spawn pads centred on the floor's z-axis. */
-    private boolean isSpawnPad(int x, int z) {
-        if (z < -1 || z > 1) return false;
-        return (x >= -RADIUS && x <= -RADIUS + 2) || (x >= RADIUS - 2 && x <= RADIUS);
-    }
 
     /**
      * Falls back to two sensible default spawns when the template doesn't

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralCrystalArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralCrystalArenaStrategy.java
@@ -72,6 +72,19 @@ public final class ProceduralCrystalArenaStrategy implements WorldGenerationStra
 		// already fully built when createWorld() returns. Only game rules remain.
 		configureWorld(world);
 
+		// Pre-load every chunk the arena footprint touches. On Paper, spawn-area
+		// chunks are already generated during createWorld(). On Spigot and other
+		// Bukkit implementations only the chunk at the world spawn may be ready —
+		// explicitly calling getChunkAt() triggers generateSurface() for any
+		// remaining chunks, guaranteeing the arena is fully built on all server types.
+		int minC = Math.floorDiv(-RADIUS, 16);
+		int maxC = Math.floorDiv( RADIUS, 16);
+		for (int cx = minC; cx <= maxC; cx++) {
+			for (int cz = minC; cz <= maxC; cz++) {
+				world.getChunkAt(cx, cz);
+			}
+		}
+
 		plugin.getLogger().info("Built procedural crystal arena " + worldName + " from template " + template.id());
 		return new ArenaInstance(id, template.id(), world.getName(),
 				spawnsFor(template), template.spectatorSpawn());
@@ -97,6 +110,12 @@ public final class ProceduralCrystalArenaStrategy implements WorldGenerationStra
 		world.setTime(6000L);
 		world.setStorm(false);
 		world.setThundering(false);
+		// Constrain the world border to just outside the arena so the server never
+		// generates chunks beyond the arena footprint. Works on all Bukkit implementations.
+		// setWarningDistance(0) suppresses the red vignette inside the arena walls.
+		world.getWorldBorder().setCenter(0, 0);
+		world.getWorldBorder().setSize(RADIUS * 2 + 1 + 48.0);
+		world.getWorldBorder().setWarningDistance(0);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralCrystalArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralCrystalArenaStrategy.java
@@ -3,16 +3,21 @@ package com.pvpindex.battles.world;
 import com.pvpindex.battles.arena.SpawnPoint;
 import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.GameRule;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
-import org.bukkit.block.Block;
+import org.bukkit.generator.BlockPopulator;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.WorldInfo;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Builds a Crystal PvP arena in a fresh void world, in code, with no asset
@@ -55,7 +60,7 @@ public final class ProceduralCrystalArenaStrategy implements WorldGenerationStra
 		}
 
 		WorldCreator creator = new WorldCreator(worldName)
-				.generator(new VoidWorldGenerator())
+				.generator(new CrystalArenaChunkGenerator())
 				.type(WorldType.NORMAL)
 				.generateStructures(false);
 		World world = Bukkit.createWorld(creator);
@@ -63,8 +68,9 @@ public final class ProceduralCrystalArenaStrategy implements WorldGenerationStra
 			throw new IOException("Failed to create crystal arena world: " + worldName);
 		}
 
+		// Arena structure is embedded in the ChunkGenerator — spawn chunks are
+		// already fully built when createWorld() returns. Only game rules remain.
 		configureWorld(world);
-		buildArena(world);
 
 		plugin.getLogger().info("Built procedural crystal arena " + worldName + " from template " + template.id());
 		return new ArenaInstance(id, template.id(), world.getName(),
@@ -99,26 +105,56 @@ public final class ProceduralCrystalArenaStrategy implements WorldGenerationStra
 		if (rule != null) world.setGameRule(rule, value);
 	}
 
-	private void buildArena(World world) {
-		for (int x = -RADIUS; x <= RADIUS; x++) {
-			for (int z = -RADIUS; z <= RADIUS; z++) {
-				world.getBlockAt(x, FLOOR_Y, z).setType(Material.OBSIDIAN, false);
+	// -------------------------------------------------------------------------
+	// Chunk generator
+	// -------------------------------------------------------------------------
+
+	private static final class CrystalArenaChunkGenerator extends ChunkGenerator {
+
+		@Override
+		public void generateSurface(@NotNull WorldInfo worldInfo, @NotNull Random random,
+									int chunkX, int chunkZ, @NotNull ChunkData chunkData) {
+			int blockMinX = chunkX * 16;
+			int blockMinZ = chunkZ * 16;
+			int startX = Math.max(-RADIUS, blockMinX);
+			int endX   = Math.min( RADIUS, blockMinX + 15);
+			int startZ = Math.max(-RADIUS, blockMinZ);
+			int endZ   = Math.min( RADIUS, blockMinZ + 15);
+			if (startX > endX || startZ > endZ) return;
+
+			for (int wx = startX; wx <= endX; wx++) {
+				int lx = wx - blockMinX;
+				for (int wz = startZ; wz <= endZ; wz++) {
+					int lz = wz - blockMinZ;
+					boolean perimeter = (wx == -RADIUS || wx == RADIUS || wz == -RADIUS || wz == RADIUS);
+					// Floor
+					chunkData.setBlock(lx, FLOOR_Y, lz, Material.OBSIDIAN);
+					// Perimeter wall: WALL_BASE obsidian + WALL_GLASS glass courses
+					if (perimeter) {
+						for (int dy = 1; dy <= WALL_BASE + WALL_GLASS; dy++) {
+							chunkData.setBlock(lx, FLOOR_Y + dy, lz,
+									dy <= WALL_BASE ? Material.OBSIDIAN : Material.GLASS);
+						}
+					}
+				}
 			}
 		}
-		for (int x = -RADIUS; x <= RADIUS; x++) {
-			placeWall(world, x, -RADIUS);
-			placeWall(world, x,  RADIUS);
-		}
-		for (int z = -RADIUS + 1; z <= RADIUS - 1; z++) {
-			placeWall(world, -RADIUS, z);
-			placeWall(world,  RADIUS, z);
-		}
-	}
 
-	private void placeWall(World world, int x, int z) {
-		for (int dy = 1; dy <= WALL_BASE + WALL_GLASS; dy++) {
-			Material mat = (dy <= WALL_BASE) ? Material.OBSIDIAN : Material.GLASS;
-			world.getBlockAt(x, FLOOR_Y + dy, z).setType(mat, false);
+		@Override public boolean shouldGenerateNoise()       { return false; }
+		@Override public boolean shouldGenerateSurface()     { return false; }
+		@Override public boolean shouldGenerateCaves()       { return false; }
+		@Override public boolean shouldGenerateDecorations() { return false; }
+		@Override public boolean shouldGenerateMobs()        { return false; }
+		@Override public boolean shouldGenerateStructures()  { return false; }
+
+		@Override
+		public @NotNull Location getFixedSpawnLocation(@NotNull World world, @NotNull Random random) {
+			return new Location(world, 0, FLOOR_Y + 1, 0);
+		}
+
+		@Override
+		public @NotNull List<BlockPopulator> getDefaultPopulators(@NotNull World world) {
+			return List.of();
 		}
 	}
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralSumoArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralSumoArenaStrategy.java
@@ -68,6 +68,19 @@ public final class ProceduralSumoArenaStrategy implements WorldGenerationStrateg
 		// already fully built when createWorld() returns. Only game rules remain.
 		configureWorld(world);
 
+		// Pre-load every chunk the arena footprint touches. On Paper, spawn-area
+		// chunks are already generated during createWorld(). On Spigot and other
+		// Bukkit implementations only the chunk at the world spawn may be ready —
+		// explicitly calling getChunkAt() triggers generateSurface() for any
+		// remaining chunks, guaranteeing the arena is fully built on all server types.
+		int minC = Math.floorDiv(-HALF, 16);
+		int maxC = Math.floorDiv( HALF, 16);
+		for (int cx = minC; cx <= maxC; cx++) {
+			for (int cz = minC; cz <= maxC; cz++) {
+				world.getChunkAt(cx, cz);
+			}
+		}
+
 		plugin.getLogger().info("Built procedural sumo arena " + worldName + " from template " + template.id());
 		return new ArenaInstance(id, template.id(), world.getName(),
 				spawnsFor(template), template.spectatorSpawn());
@@ -94,6 +107,12 @@ public final class ProceduralSumoArenaStrategy implements WorldGenerationStrateg
 		world.setStorm(false);
 		world.setThundering(false);
 		applyRule(world, "fallDamage", true);
+		// Set the world border generously beyond the platform to prevent distant
+		// chunk generation while still leaving room for knockback gameplay.
+		// setWarningDistance(0) suppresses the red vignette during normal play.
+		world.getWorldBorder().setCenter(0, 0);
+		world.getWorldBorder().setSize(HALF * 2 + 1 + 64.0);
+		world.getWorldBorder().setWarningDistance(0);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralSumoArenaStrategy.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/world/ProceduralSumoArenaStrategy.java
@@ -3,16 +3,21 @@ package com.pvpindex.battles.world;
 import com.pvpindex.battles.arena.SpawnPoint;
 import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.GameRule;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
-import org.bukkit.block.Block;
+import org.bukkit.generator.BlockPopulator;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.WorldInfo;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Builds a Sumo arena: a small elevated platform surrounded by void.
@@ -51,7 +56,7 @@ public final class ProceduralSumoArenaStrategy implements WorldGenerationStrateg
 		}
 
 		WorldCreator creator = new WorldCreator(worldName)
-				.generator(new VoidWorldGenerator())
+				.generator(new SumoArenaChunkGenerator())
 				.type(WorldType.NORMAL)
 				.generateStructures(false);
 		World world = Bukkit.createWorld(creator);
@@ -59,8 +64,9 @@ public final class ProceduralSumoArenaStrategy implements WorldGenerationStrateg
 			throw new IOException("Failed to create sumo arena world: " + worldName);
 		}
 
+		// Arena structure is embedded in the ChunkGenerator — spawn chunks are
+		// already fully built when createWorld() returns. Only game rules remain.
 		configureWorld(world);
-		buildArena(world);
 
 		plugin.getLogger().info("Built procedural sumo arena " + worldName + " from template " + template.id());
 		return new ArenaInstance(id, template.id(), world.getName(),
@@ -96,13 +102,49 @@ public final class ProceduralSumoArenaStrategy implements WorldGenerationStrateg
 		if (rule != null) world.setGameRule(rule, value);
 	}
 
-	private void buildArena(World world) {
-		for (int x = -HALF; x <= HALF; x++) {
-			for (int z = -HALF; z <= HALF; z++) {
-				Block b = world.getBlockAt(x, FLOOR_Y, z);
-				boolean isBorder = (x == -HALF || x == HALF || z == -HALF || z == HALF);
-				b.setType(isBorder ? Material.CHISELED_STONE_BRICKS : Material.STONE_BRICKS, false);
+	// -------------------------------------------------------------------------
+	// Chunk generator
+	// -------------------------------------------------------------------------
+
+	private static final class SumoArenaChunkGenerator extends ChunkGenerator {
+
+		@Override
+		public void generateSurface(@NotNull WorldInfo worldInfo, @NotNull Random random,
+									int chunkX, int chunkZ, @NotNull ChunkData chunkData) {
+			int blockMinX = chunkX * 16;
+			int blockMinZ = chunkZ * 16;
+			int startX = Math.max(-HALF, blockMinX);
+			int endX   = Math.min( HALF, blockMinX + 15);
+			int startZ = Math.max(-HALF, blockMinZ);
+			int endZ   = Math.min( HALF, blockMinZ + 15);
+			if (startX > endX || startZ > endZ) return;
+
+			for (int wx = startX; wx <= endX; wx++) {
+				int lx = wx - blockMinX;
+				for (int wz = startZ; wz <= endZ; wz++) {
+					int lz = wz - blockMinZ;
+					boolean border = (wx == -HALF || wx == HALF || wz == -HALF || wz == HALF);
+					chunkData.setBlock(lx, FLOOR_Y, lz,
+							border ? Material.CHISELED_STONE_BRICKS : Material.STONE_BRICKS);
+				}
 			}
+		}
+
+		@Override public boolean shouldGenerateNoise()       { return false; }
+		@Override public boolean shouldGenerateSurface()     { return false; }
+		@Override public boolean shouldGenerateCaves()       { return false; }
+		@Override public boolean shouldGenerateDecorations() { return false; }
+		@Override public boolean shouldGenerateMobs()        { return false; }
+		@Override public boolean shouldGenerateStructures()  { return false; }
+
+		@Override
+		public @NotNull Location getFixedSpawnLocation(@NotNull World world, @NotNull Random random) {
+			return new Location(world, 0, FLOOR_Y + 1, 0);
+		}
+
+		@Override
+		public @NotNull List<BlockPopulator> getDefaultPopulators(@NotNull World world) {
+			return List.of();
 		}
 	}
 

--- a/platform-paper/src/test/java/com/pvpindex/battles/practice/PracticeSettingsTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/practice/PracticeSettingsTest.java
@@ -1,0 +1,107 @@
+package com.pvpindex.battles.practice;
+
+import java.io.StringReader;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PracticeSettings}.
+ *
+ * <p>Exercises the {@link PracticeSettings#from(YamlConfiguration)} parser and
+ * the {@link PracticeSettings#defaults()} factory.  These tests are fully
+ * self-contained — no Paper server is needed because {@code YamlConfiguration}
+ * is a plain SnakeYAML wrapper.</p>
+ */
+class PracticeSettingsTest {
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private static YamlConfiguration yaml(String content) {
+        return YamlConfiguration.loadConfiguration(new StringReader(content));
+    }
+
+    // ── defaults() ────────────────────────────────────────────────────────────
+
+    @Test
+    void defaults_botUseNmsIsFalse() {
+        assertFalse(PracticeSettings.defaults().botUseNms(),
+                "NMS fake-player must default to disabled (experimental feature)");
+    }
+
+    @Test
+    void defaults_enabledIsTrue() {
+        assertTrue(PracticeSettings.defaults().enabled());
+    }
+
+    @Test
+    void defaults_allNumericDefaults() {
+        PracticeSettings s = PracticeSettings.defaults();
+        assertEquals(5, s.reactionMaxTargets());
+        assertEquals(40, s.reactionSpawnIntervalTicks());
+        assertEquals(100, s.reactionTargetLifetimeTicks());
+        assertEquals(6.0, s.reactionArenaSpawnRadius(), 0.001);
+        assertEquals(1.5, s.reactionArenaHeightRange(), 0.001);
+        assertEquals(10, s.botAttackIntervalTicks());
+        assertEquals(0.28, s.botMoveSpeed(), 0.001);
+        assertEquals(3.0, s.botAttackDamage(), 0.001);
+    }
+
+    // ── from(yaml) — NMS flag ─────────────────────────────────────────────────
+
+    @Test
+    void from_missingNmsKey_defaultsFalse() {
+        // When the key is absent the parser should default to false.
+        YamlConfiguration cfg = yaml("practice:\n  enabled: true\n");
+        assertFalse(PracticeSettings.from(cfg).botUseNms());
+    }
+
+    @Test
+    void from_nmsKeyExplicitFalse_isFalse() {
+        YamlConfiguration cfg = yaml(
+                "practice:\n  bot:\n    use_nms_fake_player: false\n");
+        assertFalse(PracticeSettings.from(cfg).botUseNms());
+    }
+
+    @Test
+    void from_nmsKeyExplicitTrue_isTrue() {
+        YamlConfiguration cfg = yaml(
+                "practice:\n  bot:\n    use_nms_fake_player: true\n");
+        assertTrue(PracticeSettings.from(cfg).botUseNms(),
+                "Server operator explicitly opted in to the experimental NMS bot");
+    }
+
+    // ── from(yaml) — other fields ─────────────────────────────────────────────
+
+    @Test
+    void from_enabledFalse() {
+        YamlConfiguration cfg = yaml("practice:\n  enabled: false\n");
+        assertFalse(PracticeSettings.from(cfg).enabled());
+    }
+
+    @Test
+    void from_customBotKit() {
+        YamlConfiguration cfg = yaml("practice:\n  bot:\n    kit_id: crystal_kit\n");
+        assertEquals("crystal_kit", PracticeSettings.from(cfg).botKitId());
+    }
+
+    @Test
+    void from_customMoveSpeed() {
+        YamlConfiguration cfg = yaml("practice:\n  bot:\n    move_speed: 0.35\n");
+        assertEquals(0.35, PracticeSettings.from(cfg).botMoveSpeed(), 0.001);
+    }
+
+    @Test
+    void from_customReactionMaxTargets() {
+        YamlConfiguration cfg =
+                yaml("practice:\n  reaction_training:\n    max_targets: 8\n");
+        assertEquals(8, PracticeSettings.from(cfg).reactionMaxTargets());
+    }
+
+    @Test
+    void from_templateIdOverride() {
+        YamlConfiguration cfg = yaml("practice:\n  template_id: custom_arena\n");
+        assertEquals("custom_arena", PracticeSettings.from(cfg).practiceTemplateId());
+    }
+}

--- a/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/BotPlayerFactoryTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/BotPlayerFactoryTest.java
@@ -1,0 +1,161 @@
+package com.pvpindex.battles.practice.bot;
+
+import java.util.logging.Logger;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Zombie;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ * Unit tests for {@link BotPlayerFactory}.
+ *
+ * <p>Tests run on a plain JVM (no Paper server).  Bukkit interfaces are mocked with
+ * Mockito.  The static {@code nmsAdapter} field is reset after each test to prevent
+ * pollution between tests.</p>
+ */
+class BotPlayerFactoryTest {
+
+    @AfterEach
+    void resetAdapter() {
+        BotPlayerFactory.setNmsAdapter(null);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static Plugin mockPlugin() {
+        Plugin plugin = Mockito.mock(Plugin.class);
+        Mockito.when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        return plugin;
+    }
+
+    /**
+     * Returns a mocked {@link World} whose {@code spawnEntity} call yields a
+     * mocked {@link Zombie}.  Also stubs the Zombie setters so Mockito doesn't
+     * need extra setup for void-return calls.
+     */
+    private static World mockWorldWithZombie(Zombie zombie) {
+        World world = Mockito.mock(World.class);
+        Mockito.when(world.spawnEntity(any(Location.class), eq(EntityType.ZOMBIE)))
+                .thenReturn(zombie);
+        return world;
+    }
+
+    // ── useNms = false ────────────────────────────────────────────────────────
+
+    @Test
+    void spawn_useNmsFalse_adapterIgnored_zombieReturned() throws Exception {
+        BotNmsAdapter adapter = Mockito.mock(BotNmsAdapter.class);
+        BotPlayerFactory.setNmsAdapter(adapter);
+
+        Zombie zombie = Mockito.mock(Zombie.class);
+        World world = mockWorldWithZombie(zombie);
+        Location location = new Location(world, 0, 64, 0);
+
+        LivingEntity result = BotPlayerFactory.spawn(mockPlugin(), world, location, "Bot", false);
+
+        // Adapter must never be consulted when useNms is false.
+        Mockito.verify(adapter, Mockito.never()).spawnFakePlayer(any(), any(), any());
+        assertSame(zombie, result);
+    }
+
+    // ── no adapter installed ──────────────────────────────────────────────────
+
+    @Test
+    void spawn_useNmsTrue_noAdapterInstalled_zombieReturned() {
+        // nmsAdapter is null (reset in @AfterEach — also ensured by @AfterEach default state)
+        Zombie zombie = Mockito.mock(Zombie.class);
+        World world = mockWorldWithZombie(zombie);
+        Location location = new Location(world, 0, 64, 0);
+
+        LivingEntity result = BotPlayerFactory.spawn(mockPlugin(), world, location, "Bot", true);
+
+        assertSame(zombie, result);
+    }
+
+    // ── adapter returns null ──────────────────────────────────────────────────
+
+    @Test
+    void spawn_useNmsTrue_adapterReturnsNull_zombieReturned() throws Exception {
+        BotNmsAdapter adapter = Mockito.mock(BotNmsAdapter.class);
+        Mockito.when(adapter.spawnFakePlayer(any(), any(), any())).thenReturn(null);
+        BotPlayerFactory.setNmsAdapter(adapter);
+
+        Zombie zombie = Mockito.mock(Zombie.class);
+        World world = mockWorldWithZombie(zombie);
+        Location location = new Location(world, 0, 64, 0);
+
+        LivingEntity result = BotPlayerFactory.spawn(mockPlugin(), world, location, "Bot", true);
+
+        assertSame(zombie, result);
+    }
+
+    // ── adapter throws ────────────────────────────────────────────────────────
+
+    @Test
+    void spawn_useNmsTrue_adapterThrows_warningLoggedAndZombieReturned() throws Exception {
+        BotNmsAdapter adapter = Mockito.mock(BotNmsAdapter.class);
+        Mockito.when(adapter.spawnFakePlayer(any(), any(), any()))
+                .thenThrow(new RuntimeException("NMS reflection failed"));
+        BotPlayerFactory.setNmsAdapter(adapter);
+
+        Zombie zombie = Mockito.mock(Zombie.class);
+        World world = mockWorldWithZombie(zombie);
+        Location location = new Location(world, 0, 64, 0);
+        Plugin plugin = mockPlugin();
+
+        LivingEntity result = BotPlayerFactory.spawn(plugin, world, location, "Bot", true);
+
+        assertSame(zombie, result);
+        // The warning is logged via plugin.getLogger().warning(...)
+        Mockito.verify(plugin, Mockito.atLeastOnce()).getLogger();
+    }
+
+    // ── adapter succeeds ──────────────────────────────────────────────────────
+
+    @Test
+    void spawn_useNmsTrue_adapterSucceeds_fakePlayerReturned() throws Exception {
+        LivingEntity fakePlayer = Mockito.mock(LivingEntity.class);
+        BotNmsAdapter adapter = Mockito.mock(BotNmsAdapter.class);
+        Mockito.when(adapter.spawnFakePlayer(any(), any(), any())).thenReturn(fakePlayer);
+        BotPlayerFactory.setNmsAdapter(adapter);
+
+        World world = Mockito.mock(World.class);
+        Location location = new Location(world, 0, 64, 0);
+
+        LivingEntity result =
+                BotPlayerFactory.spawn(mockPlugin(), world, location, "TestBot", true);
+
+        assertSame(fakePlayer, result, "Adapter's entity should be returned directly");
+        Mockito.verify(adapter).spawnFakePlayer(world, location, "TestBot");
+        Mockito.verify(world, Mockito.never()).spawnEntity(any(), any());
+    }
+
+    // ── adapter registration ──────────────────────────────────────────────────
+
+    @Test
+    void setNmsAdapter_null_clearsAdapterAndFallsBackToZombie() throws Exception {
+        BotNmsAdapter adapter = Mockito.mock(BotNmsAdapter.class);
+        Mockito.when(adapter.spawnFakePlayer(any(), any(), any()))
+                .thenReturn(Mockito.mock(LivingEntity.class));
+        BotPlayerFactory.setNmsAdapter(adapter);
+        BotPlayerFactory.setNmsAdapter(null); // clear it
+
+        Zombie zombie = Mockito.mock(Zombie.class);
+        World world = mockWorldWithZombie(zombie);
+        Location location = new Location(world, 0, 64, 0);
+
+        LivingEntity result = BotPlayerFactory.spawn(mockPlugin(), world, location, "Bot", true);
+
+        Mockito.verify(adapter, Mockito.never()).spawnFakePlayer(any(), any(), any());
+        assertSame(zombie, result);
+    }
+}

--- a/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/NmsSpawnHelperTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/NmsSpawnHelperTest.java
@@ -1,0 +1,161 @@
+package com.pvpindex.battles.practice.bot;
+
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link NmsSpawnHelper}.
+ *
+ * <p>These tests run on a plain JVM — no Paper server present.  The intent is to
+ * verify the reflection logic in isolation:</p>
+ * <ul>
+ *   <li>Methods that search for specific NMS classes return {@code null} / throw
+ *       predictably when those classes are absent.</li>
+ *   <li>Methods that operate on arbitrary {@code Object} instances (e.g.
+ *       {@code addFreshEntityReflective}, {@code tryRemoveEntity}) behave
+ *       correctly given in-test proxy objects.</li>
+ * </ul>
+ */
+class NmsSpawnHelperTest {
+
+    // ── resolveClientInformationDefault ──────────────────────────────────────
+
+    @Test
+    void resolveClientInformationDefault_noNmsClasses_returnsNull() {
+        // In the test JVM there are no net.minecraft.* classes; expect null, not an
+        // exception.
+        assertNull(NmsSpawnHelper.resolveClientInformationDefault());
+    }
+
+    // ── resolveServerPlayerConstructor ───────────────────────────────────────
+
+    @Test
+    void resolveServerPlayerConstructor_4ParamClass_returnsConstructor()
+            throws NoSuchMethodException {
+        Constructor<?> ctor =
+                NmsSpawnHelper.resolveServerPlayerConstructor(Fake4ParamClass.class);
+        assertNotNull(ctor);
+        assertEquals(4, ctor.getParameterCount());
+    }
+
+    @Test
+    void resolveServerPlayerConstructor_noMatchingConstructor_throws() {
+        // Object has only a 0-param constructor — should throw.
+        assertThrows(NoSuchMethodException.class,
+                () -> NmsSpawnHelper.resolveServerPlayerConstructor(Object.class));
+    }
+
+    @Test
+    void resolveServerPlayerConstructor_2ParamClass_throws() {
+        assertThrows(NoSuchMethodException.class,
+                () -> NmsSpawnHelper.resolveServerPlayerConstructor(Fake2ParamClass.class));
+    }
+
+    // ── addFreshEntityReflective ─────────────────────────────────────────────
+
+    @Test
+    void addFreshEntityReflective_1ParamMethod_invoked() throws Exception {
+        FakeLevel1Param level = new FakeLevel1Param();
+        Object entity = new Object();
+        NmsSpawnHelper.addFreshEntityReflective(level, entity);
+        assertTrue(level.called, "addFreshEntity(Object) should have been called");
+        assertSame(entity, level.receivedEntity);
+    }
+
+    @Test
+    void addFreshEntityReflective_2ParamMethod_invoked() throws Exception {
+        FakeLevel2Param level = new FakeLevel2Param();
+        Object entity = new Object();
+        NmsSpawnHelper.addFreshEntityReflective(level, entity);
+        assertTrue(level.called, "addFreshEntity(Object, FakeSpawnReason) should have been called");
+    }
+
+    @Test
+    void addFreshEntityReflective_noMatchingMethod_throwsNoSuchMethodException() {
+        // Plain Object has no addFreshEntity method.
+        assertThrows(NoSuchMethodException.class,
+                () -> NmsSpawnHelper.addFreshEntityReflective(new Object(), new Object()));
+    }
+
+    // ── tryRemoveEntity ───────────────────────────────────────────────────────
+
+    @Test
+    void tryRemoveEntity_nullLevel_doesNotThrow() {
+        // nmsLevel is null — the method must silently skip removePlayerImmediately
+        // and attempt the entity-level fallbacks.
+        assertDoesNotThrow(() -> NmsSpawnHelper.tryRemoveEntity(null, new FakeDiscardable()));
+    }
+
+    @Test
+    void tryRemoveEntity_entityWithDiscardMethod_fallbackInvoked() {
+        // No NMS RemovalReason in the test JVM, so the code falls all the way to
+        // entity.discard() which is the last-resort fallback.
+        FakeDiscardable entity = new FakeDiscardable();
+        NmsSpawnHelper.tryRemoveEntity(null, entity);
+        assertTrue(entity.discardCalled,
+                "discard() should be called as the last-resort fallback");
+    }
+
+    @Test
+    void tryRemoveEntity_entityWithNoCleanupMethods_doesNotThrow() {
+        // An entity with none of the cleanup methods — must not throw.
+        assertDoesNotThrow(() -> NmsSpawnHelper.tryRemoveEntity(null, new Object()));
+    }
+
+    @Test
+    void tryRemoveEntity_bothLevelAndEntityPresent_doesNotThrow() {
+        // Exercises the branch where nmsLevel != null but has no removePlayerImmediately.
+        assertDoesNotThrow(
+                () -> NmsSpawnHelper.tryRemoveEntity(new Object(), new FakeDiscardable()));
+    }
+
+    // ── Helper classes ────────────────────────────────────────────────────────
+
+    /** Represents a class that has a 4-parameter constructor. */
+    @SuppressWarnings("unused")
+    static class Fake4ParamClass {
+        public Fake4ParamClass(Object a, Object b, Object c, Object d) {}
+    }
+
+    /** Represents a class with only a 2-parameter constructor (no 4-param match). */
+    @SuppressWarnings("unused")
+    static class Fake2ParamClass {
+        public Fake2ParamClass(Object a, Object b) {}
+    }
+
+    /** Simulates a ServerLevel with {@code addFreshEntity(Object)} (1-param variant). */
+    @SuppressWarnings("unused")
+    static class FakeLevel1Param {
+        boolean called;
+        Object receivedEntity;
+
+        public void addFreshEntity(Object entity) {
+            called = true;
+            receivedEntity = entity;
+        }
+    }
+
+    /** Simulates a ServerLevel with {@code addFreshEntity(Object, FakeSpawnReason)} (2-param). */
+    @SuppressWarnings("unused")
+    static class FakeLevel2Param {
+        boolean called;
+
+        public enum FakeSpawnReason { DEFAULT }
+
+        public void addFreshEntity(Object entity, FakeSpawnReason reason) {
+            called = true;
+        }
+    }
+
+    /** Simulates an NMS entity that exposes {@code discard()}.  */
+    @SuppressWarnings("unused")
+    static class FakeDiscardable {
+        boolean discardCalled;
+
+        public void discard() {
+            discardCalled = true;
+        }
+    }
+}

--- a/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/NmsSpawnHelperTest.java
+++ b/platform-paper/src/test/java/com/pvpindex/battles/practice/bot/NmsSpawnHelperTest.java
@@ -83,8 +83,8 @@ class NmsSpawnHelperTest {
 
     @Test
     void tryRemoveEntity_nullLevel_doesNotThrow() {
-        // nmsLevel is null — the method must silently skip removePlayerImmediately
-        // and attempt the entity-level fallbacks.
+        // nmsLevel is null — the method must silently skip removePlayerImmediately,
+        // skip the WaypointManager cleanup, and attempt the entity-level fallbacks.
         assertDoesNotThrow(() -> NmsSpawnHelper.tryRemoveEntity(null, new FakeDiscardable()));
     }
 
@@ -106,9 +106,38 @@ class NmsSpawnHelperTest {
 
     @Test
     void tryRemoveEntity_bothLevelAndEntityPresent_doesNotThrow() {
-        // Exercises the branch where nmsLevel != null but has no removePlayerImmediately.
+        // Exercises the branch where nmsLevel != null but has no removePlayerImmediately
+        // and no ServerWaypointManager field.
         assertDoesNotThrow(
                 () -> NmsSpawnHelper.tryRemoveEntity(new Object(), new FakeDiscardable()));
+    }
+
+    @Test
+    void tryRemoveEntity_levelWithWaypointManager_removePlayerCalled() {
+        // Simulates the Paper 26.1.x scenario: the level has a ServerWaypointManager
+        // field.  The cleanup must call removePlayer() on it directly to unregister
+        // the fake bot as a waypoint receiver, even when EntityLookup fails.
+        FakeLevelWithWaypointManager level = new FakeLevelWithWaypointManager();
+        FakeDiscardable entity = new FakeDiscardable();
+
+        NmsSpawnHelper.tryRemoveEntity(level, entity);
+
+        assertTrue(level.serverWaypointManager.removePlayerCalled,
+                "ServerWaypointManager.removePlayer() must be called as the waypoint cleanup safety net");
+        assertSame(entity, level.serverWaypointManager.removedEntity);
+    }
+
+    @Test
+    void tryRemoveEntity_levelWithWaypointManager_discardStillCalledAsFinalFallback() {
+        // Verifies that the cleanup chain continues past the WaypointManager call
+        // (no early return) and reaches discard() when no setRemoved method exists.
+        FakeLevelWithWaypointManager level = new FakeLevelWithWaypointManager();
+        FakeDiscardable entity = new FakeDiscardable();
+
+        NmsSpawnHelper.tryRemoveEntity(level, entity);
+
+        assertTrue(entity.discardCalled,
+                "discard() should still be called after the WaypointManager safety net");
     }
 
     // ── Helper classes ────────────────────────────────────────────────────────
@@ -157,5 +186,31 @@ class NmsSpawnHelperTest {
         public void discard() {
             discardCalled = true;
         }
+    }
+
+    /**
+     * Simulates a {@code net.minecraft.server.waypoints.ServerWaypointManager}.
+     * The simple class name "ServerWaypointManager" is what the reflective field
+     * scan matches on.
+     */
+    @SuppressWarnings("unused")
+    static class ServerWaypointManager {
+        boolean removePlayerCalled;
+        Object removedEntity;
+
+        public void removePlayer(Object player) {
+            removePlayerCalled = true;
+            removedEntity = player;
+        }
+    }
+
+    /**
+     * Simulates a {@code ServerLevel} that holds a {@code ServerWaypointManager} field.
+     * The field is declared {@code public} so that reflection can access it without
+     * setAccessible in the test JVM's unnamed module.
+     */
+    @SuppressWarnings("unused")
+    static class FakeLevelWithWaypointManager {
+        public final ServerWaypointManager serverWaypointManager = new ServerWaypointManager();
     }
 }


### PR DESCRIPTION
New features:
- /practice command with reaction training and bot duel modes
- Reaction training: glowing ArmorStand targets with END_ROD/WAX_ON/FIREWORK particle animations; tracks reaction time, hits, misses, and combos
- Bot duel: NMS fake ServerPlayer (reflection, Zombie fallback) with simple strafe/attack AI (BotBehaviorTask); applies kit from config
- PracticeManager: session lifecycle, save/restore player state
- PracticeListener: handles ArmorStand hits, bot death, GUI clicks
- Practice tab in /battle GUI at slot 39 (BOOK)
- practice.yml config for enabling/tuning both modes
- pvpindex.practice permission (default: true)

Tech details:
- GameProfile created via reflection (no compile-time authlib dependency)
- Uses GENERIC_MAX_HEALTH attribute (paper-api 1.21.1 compat)
- Folia-safe entity scheduler for particle tasks