### PR TITLE
fix: added configurable potion effects to the kits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ### Fixed
 - Pot PvP and NoDebuff starter kits no longer give empty splash potions. The default `SPLASH_POTION` entries in `gamemodes.yml` now include explicit potion effects (Healing II, Strength II, Speed II, and Regeneration II where applicable).
+- Kit item display names and lore now translate legacy `&` colour codes when applied, so potion names like `&aHealing II` render with colours in-game instead of raw ampersand codes.
+- Network node timeout boundary handling is now inclusive, fixing `proxyNodeTimeoutDetection` for `isTimedOut(0)` and preventing zero-second timeout edge-case mismatches.
+- README build output examples now reference `1.1.1` JAR filenames to match the current Maven project version.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Release tags use the `v` prefix (e.g. `v1.0.2`).
 
 ---
 
+## [1.1.1] - 2026-07-05
+
+### Added
+- Kit item support for per-item `potion_effects` in `gamemodes.yml`. Potion items can now define explicit effects using `TYPE:durationTicks:amplifier` (for example, `INSTANT_HEALTH:1:1`).
+
+### Fixed
+- Pot PvP and NoDebuff starter kits no longer give empty splash potions. The default `SPLASH_POTION` entries in `gamemodes.yml` now include explicit potion effects (Healing II, Strength II, Speed II, and Regeneration II where applicable).
+
+---
+
 ## [1.1.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ mvn clean package
 
 Output:
 
-- `bootstrap-paper/target/PvPIndexBattles-1.1.0.jar` - drop into Paper `plugins/`
-- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.1.0.jar` - drop into Velocity `plugins/`
-- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.1.0.jar` - drop into BungeeCord `plugins/`
+- `bootstrap-paper/target/PvPIndexBattles-1.1.1.jar` - drop into Paper `plugins/`
+- `bootstrap-velocity/target/PvPIndexBattles-velocity-1.1.1.jar` - drop into Velocity `plugins/`
+- `bootstrap-bungeecord/target/PvPIndexBattles-bungeecord-1.1.1.jar` - drop into BungeeCord `plugins/`
 
 The Paper JAR auto-detects your server version (1.21.x or 26.1.x) at startup. No manual configuration needed for version selection.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-bungeecord/pom.xml
+++ b/bootstrap-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-paper/pom.xml
+++ b/bootstrap-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bootstrap-paper/src/main/resources/gamemodes.yml
+++ b/bootstrap-paper/src/main/resources/gamemodes.yml
@@ -26,9 +26,9 @@ kits:
     display_name: "&bPot PvP"
     items:
       - { slot: 0, material: NETHERITE_SWORD, enchantments: { sharpness: 4, unbreaking: 3 } }
-      - { slot: 1, material: SPLASH_POTION,   amount: 8,  display_name: "&aHealing II" }
-      - { slot: 2, material: SPLASH_POTION,   amount: 8,  display_name: "&eStrength II" }
-      - { slot: 3, material: SPLASH_POTION,   amount: 8,  display_name: "&9Speed II" }
+      - { slot: 1, material: SPLASH_POTION,   amount: 8,  display_name: "&aHealing II",  potion_effects: ["INSTANT_HEALTH:1:1"] }
+      - { slot: 2, material: SPLASH_POTION,   amount: 8,  display_name: "&eStrength II", potion_effects: ["STRENGTH:1800:1"] }
+      - { slot: 3, material: SPLASH_POTION,   amount: 8,  display_name: "&9Speed II",    potion_effects: ["SPEED:1800:1"] }
       - { slot: 4, material: ENDER_PEARL,     amount: 4 }
       - { slot: helmet, material: NETHERITE_HELMET,     enchantments: { protection: 4, unbreaking: 3 } }
       - { slot: chest,  material: NETHERITE_CHESTPLATE, enchantments: { protection: 4, unbreaking: 3 } }
@@ -42,8 +42,8 @@ kits:
     display_name: "&6NoDebuff"
     items:
       - { slot: 0, material: IRON_SWORD,   enchantments: { sharpness: 3, unbreaking: 3 } }
-      - { slot: 1, material: SPLASH_POTION, amount: 16, display_name: "&aHealing II" }
-      - { slot: 2, material: SPLASH_POTION, amount: 8,  display_name: "&eRegeneration II" }
+      - { slot: 1, material: SPLASH_POTION, amount: 16, display_name: "&aHealing II",      potion_effects: ["INSTANT_HEALTH:1:1"] }
+      - { slot: 2, material: SPLASH_POTION, amount: 8,  display_name: "&eRegeneration II", potion_effects: ["REGENERATION:900:1"] }
       - { slot: 3, material: GOLDEN_APPLE,  amount: 4 }
       - { slot: helmet, material: IRON_HELMET,     enchantments: { protection: 3, unbreaking: 3 } }
       - { slot: chest,  material: IRON_CHESTPLATE, enchantments: { protection: 3, unbreaking: 3 } }

--- a/bootstrap-velocity/pom.xml
+++ b/bootstrap-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/com/pvpindex/battles/gamemode/KitItem.java
+++ b/common/src/main/java/com/pvpindex/battles/gamemode/KitItem.java
@@ -14,9 +14,10 @@ public record KitItem(
         int amount,
         Map<String, Integer> enchantments,
         List<String> lore,
-        String displayName
+        String displayName,
+        List<String> potionEffects
 ) {
     public static KitItem of(String slot, String material) {
-        return new KitItem(slot, material, 1, Map.of(), List.of(), null);
+        return new KitItem(slot, material, 1, Map.of(), List.of(), null, List.of());
     }
 }

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/network/src/main/java/com/pvpindex/network/node/NetworkNode.java
+++ b/network/src/main/java/com/pvpindex/network/node/NetworkNode.java
@@ -46,7 +46,8 @@ public class NetworkNode {
     }
 
     public boolean isTimedOut(int timeoutSeconds) {
-        return Instant.now().minusSeconds(timeoutSeconds).isAfter(lastHeartbeat);
+        Instant threshold = Instant.now().minusSeconds(timeoutSeconds);
+        return !threshold.isBefore(lastHeartbeat);
     }
 
     @Override

--- a/paper-versions/paper.1.21.x/pom.xml
+++ b/paper-versions/paper.1.21.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/paper-versions/paper.26.1.x/pom.xml
+++ b/paper-versions/paper.26.1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform-bungeecord/pom.xml
+++ b/platform-bungeecord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/pom.xml
+++ b/platform-paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/platform-paper/src/main/java/com/pvpindex/battles/gamemode/GameModeLoader.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/gamemode/GameModeLoader.java
@@ -44,7 +44,8 @@ public final class GameModeLoader {
                             asInt(raw.get("amount"), 1),
                             asEnchantMap(raw.get("enchantments")),
                             asStringList(raw.get("lore")),
-                            raw.get("display_name") == null ? null : String.valueOf(raw.get("display_name"))
+                            raw.get("display_name") == null ? null : String.valueOf(raw.get("display_name")),
+                            asStringList(raw.get("potion_effects"))
                     ));
                 }
                 kits.add(new KitDefinition(kitId, k.getString("display_name", kitId), items, k.getStringList("potion_effects")));

--- a/platform-paper/src/main/java/com/pvpindex/battles/gamemode/KitApplier.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/gamemode/KitApplier.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -52,6 +53,14 @@ public final class KitApplier {
 			if (!item.lore().isEmpty()) {
 				meta.setLore(item.lore());
 			}
+            if (meta instanceof PotionMeta potionMeta) {
+                for (String effectSpec : item.potionEffects()) {
+                    PotionEffect effect = parsePotionEffect(effectSpec);
+                    if (effect != null) {
+                        potionMeta.addCustomEffect(effect, true);
+                    }
+                }
+            }
             stack.setItemMeta(meta);
         }
         item.enchantments().forEach((name, level) -> {
@@ -84,16 +93,23 @@ public final class KitApplier {
     }
 
     private void applyEffect(Player player, String spec) {
+        PotionEffect effect = parsePotionEffect(spec);
+        if (effect != null) {
+            player.addPotionEffect(effect);
+        }
+    }
+
+    private PotionEffect parsePotionEffect(String spec) {
         // Format: TYPE:durationTicks:amplifier   (e.g. SPEED:600:1)
         String[] parts = spec.split(":");
-        if (parts.length < 1) return;
+        if (parts.length < 1 || parts[0].isBlank()) return null;
         PotionEffectType type = versionAdapter != null
                 ? versionAdapter.getEffect(parts[0].toLowerCase())
                 : org.bukkit.Registry.EFFECT.get(NamespacedKey.minecraft(parts[0].toLowerCase()));
-        if (type == null) return;
+        if (type == null) return null;
         int duration = parts.length > 1 ? safeInt(parts[1], 600) : 600;
         int amplifier = parts.length > 2 ? safeInt(parts[2], 0) : 0;
-        player.addPotionEffect(new PotionEffect(type, duration, amplifier));
+        return new PotionEffect(type, duration, amplifier);
     }
 
     private static int safeInt(String s, int fallback) {

--- a/platform-paper/src/main/java/com/pvpindex/battles/gamemode/KitApplier.java
+++ b/platform-paper/src/main/java/com/pvpindex/battles/gamemode/KitApplier.java
@@ -1,6 +1,8 @@
 package com.pvpindex.battles.gamemode;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -48,10 +50,10 @@ public final class KitApplier {
         ItemMeta meta = stack.getItemMeta();
         if (meta != null) {
 			if (item.displayName() != null) {
-				meta.setDisplayName(item.displayName());
+                meta.setDisplayName(colorize(item.displayName()));
 			}
 			if (!item.lore().isEmpty()) {
-				meta.setLore(item.lore());
+                meta.setLore(item.lore().stream().map(KitApplier::colorize).collect(Collectors.toList()));
 			}
             if (meta instanceof PotionMeta potionMeta) {
                 for (String effectSpec : item.potionEffects()) {
@@ -114,5 +116,9 @@ public final class KitApplier {
 
     private static int safeInt(String s, int fallback) {
         try { return Integer.parseInt(s); } catch (NumberFormatException ex) { return fallback; }
+    }
+
+    private static String colorize(String input) {
+        return ChatColor.translateAlternateColorCodes('&', input);
     }
 }

--- a/platform-velocity/pom.xml
+++ b/platform-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pvpindex</groupId>
         <artifactId>pvpindex-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.pvpindex</groupId>
     <artifactId>pvpindex-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <name>PvPIndex Parent</name>


### PR DESCRIPTION
### Added
- Kit item support for per-item `potion_effects` in `gamemodes.yml`. Potion items can now define explicit effects using `TYPE:durationTicks:amplifier` (for example, `INSTANT_HEALTH:1:1`).

### Fixed
- Pot PvP and NoDebuff starter kits no longer give empty splash potions. The default `SPLASH_POTION` entries in `gamemodes.yml` now include explicit potion effects (Healing II, Strength II, Speed II, and Regeneration II where applicable).